### PR TITLE
Initialize aka Get Started

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Hello World!</title>
+  </head>
+  <body>
+    <h1>Hello World!</h1>
+    We are using io.js <script>document.write(process.version)</script>
+    and Electron <script>document.write(process.versions['electron'])</script>.
+  </body>
+</html>

--- a/main.js
+++ b/main.js
@@ -1,0 +1,33 @@
+var app = require('app');  // Module to control application life.
+var BrowserWindow = require('browser-window');  // Module to create native browser window.
+
+// Report crashes to our server.
+require('crash-reporter').start();
+
+// Keep a global reference of the window object, if you don't, the window will
+// be closed automatically when the javascript object is GCed.
+var mainWindow = null;
+
+// Quit when all windows are closed.
+app.on('window-all-closed', function() {
+  if (process.platform != 'darwin')
+    app.quit();
+});
+
+// This method will be called when Electron has done everything
+// initialization and ready for creating browser windows.
+app.on('ready', function() {
+  // Create the browser window.
+  mainWindow = new BrowserWindow({width: 800, height: 600});
+
+  // and load the index.html of the app.
+  mainWindow.loadUrl('file://' + __dirname + '/index.html');
+
+  // Emitted when the window is closed.
+  mainWindow.on('closed', function() {
+    // Dereference the window object, usually you would store windows
+    // in an array if your app supports multi windows, this is the time
+    // when you should delete the corresponding element.
+    mainWindow = null;
+  });
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "git-it-electron",
+  "version": "1.0.0",
+  "description": "### A Git-it Desktop App!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!",
+  "main": "main.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jlord/git-it-electron.git"
+  },
+  "author": "Jessica Lord",
+  "license": "BSD",
+  "bugs": {
+    "url": "https://github.com/jlord/git-it-electron/issues"
+  },
+  "homepage": "https://github.com/jlord/git-it-electron",
+  "devDependencies": {
+    "electron-prebuilt": "^0.25.2"
+  }
+}


### PR DESCRIPTION
With just these first few steps we get an Electron app displaying the default site:

![screen shot 2015-05-08 at 2 29 40 pm](https://cloud.githubusercontent.com/assets/1305617/7545994/beec937e-f58e-11e4-9424-1c831f557b50.png)

Since Git-it's content will mostly be the [guide](http://jlord.github.io/git-it), which is a website, starting with a website like this is :sparkles: 

## Commits (Steps):

Here's what went down in this PR.

### npm init

From inside this directory (folder), `git-it-electron`, on my computer, I initialized it with npm, which manages the packages (other bits of code) that we'll use as well as this app itself when it is later published. To initialize:

```bash
# from inside of /git-it-electron
$ npm init
```
Then I hit enter a lot so that it builds me the bare-bones package.json to describe the project. Next I open that file in my text editor ([Atom](http://atom.io)!) and fill in some of the data (like my name and the license). 

### Quick Start files

Electron has a [Quick Start guide](https://github.com/atom/electron/blob/master/docs/tutorial/quick-start.md) which provides a sample `main.js` and `index.html` for an app. I just copied them directly from the website and pasted them into files and saved with the corresponding name. 

### electron-prebuilt

The module `electron-prebuilt` gives you access to Electron from the command line. Then you can launch Electron apps by running this inside of the `git-it-electron` directory. I installed this globally so that I can use it from anywhere on my system.

```bash
$ npm install -g electron-prebuilt
# from inside of /git-it-electron
$ electron main.js
```

That's how I launched this and got the window for the screenshot at the top. 