### PR TITLE
Clean up main.js, add JavaScript Standard Style

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,33 +1,22 @@
-var app = require('app');  // Module to control application life.
-var BrowserWindow = require('browser-window');  // Module to create native browser window.
+var app = require('app')
+var BrowserWindow = require('browser-window')
+var crashReporter = require('crash-reporter')
 
-// Report crashes to our server.
-require('crash-reporter').start();
+crashReporter.start()
 
-// Keep a global reference of the window object, if you don't, the window will
-// be closed automatically when the javascript object is GCed.
-var mainWindow = null;
+var mainWindow = null
 
-// Quit when all windows are closed.
-app.on('window-all-closed', function() {
-  if (process.platform != 'darwin')
-    app.quit();
-});
+app.on('window-all-closed', function appQuit () {
+  if (process.platform !== 'darwin') {
+    app.quit()
+  }
+})
 
-// This method will be called when Electron has done everything
-// initialization and ready for creating browser windows.
-app.on('ready', function() {
-  // Create the browser window.
-  mainWindow = new BrowserWindow({width: 800, height: 600});
+app.on('ready', function appReady () {
+  mainWindow = new BrowserWindow({width: 800, height: 600})
+  mainWindow.loadUrl('file://' + __dirname + '/index.html')
 
-  // and load the index.html of the app.
-  mainWindow.loadUrl('file://' + __dirname + '/index.html');
-
-  // Emitted when the window is closed.
-  mainWindow.on('closed', function() {
-    // Dereference the window object, usually you would store windows
-    // in an array if your app supports multi windows, this is the time
-    // when you should delete the corresponding element.
-    mainWindow = null;
-  });
-});
+  mainWindow.on('closed', function winClosed () {
+    mainWindow = null
+  })
+})

--- a/package.json
+++ b/package.json
@@ -18,5 +18,8 @@
   "homepage": "https://github.com/jlord/git-it-electron",
   "devDependencies": {
     "electron-prebuilt": "^0.25.2"
+  },
+  "dependencies": {
+    "standard": "^3.7.3"
   }
 }


### PR DESCRIPTION
In this PR I clean up the extra comments from the [Quick Start guide](https://github.com/atom/electron/blob/master/docs/tutorial/quick-start.md) that I copied. 

I also installed [`standard` package](https://www.npmjs.com/package/standard) which is a library that helps you lint (aka clean/format) your code to a certain style. I've picked this style! I've also got the [Standard linter](https://atom.io/packages/linter-js-standard) running in my editor, Atom, alerting while I type. But I'll use the one I've installed here later on. 

If I wanted to use it on my `main.js` from terminal I would:

```bash
# from inside /git-it-electron
$ npm install standard
$ standard main.js
```

It will report back on the things it found :sparkle: 