### PR TITLE
Add menu and DevTools

### DIFF
--- a/darwin-menu.js
+++ b/darwin-menu.js
@@ -1,0 +1,135 @@
+module.exports = function menu (app, mainWindow) {
+  var darwinMenu = [
+    {
+      label: 'Git-it',
+      submenu: [
+        {
+          label: 'About Git-it',
+          selector: 'orderFrontStandardAboutPanel:'
+        },
+        {
+          type: 'separator'
+        },
+        {
+          label: 'Services',
+          submenu: []
+        },
+        {
+          type: 'separator'
+        },
+        {
+          label: 'Hide Git-it',
+          accelerator: 'Command+H',
+          selector: 'hide:'
+        },
+        {
+          label: 'Hide Others',
+          accelerator: 'Command+Shift+H',
+          selector: 'hideOtherApplications:'
+        },
+        {
+          label: 'Show All',
+          selector: 'unhideAllApplications:'
+        },
+        {
+          type: 'separator'
+        },
+        {
+          label: 'Quit',
+          accelerator: 'Command+Q',
+          click: function () { app.quit() }
+        }
+      ]
+    },
+    {
+      label: 'Edit',
+      submenu: [
+        {
+          label: 'Undo',
+          accelerator: 'Command+Z',
+          selector: 'undo:'
+        },
+        {
+          label: 'Redo',
+          accelerator: 'Shift+Command+Z',
+          selector: 'redo:'
+        },
+        {
+          type: 'separator'
+        },
+        {
+          label: 'Cut',
+          accelerator: 'Command+X',
+          selector: 'cut:'
+        },
+        {
+          label: 'Copy',
+          accelerator: 'Command+C',
+          selector: 'copy:'
+        },
+        {
+          label: 'Paste',
+          accelerator: 'Command+V',
+          selector: 'paste:'
+        },
+        {
+          label: 'Select All',
+          accelerator: 'Command+A',
+          selector: 'selectAll:'
+        }
+      ]
+    },
+    {
+      label: 'View',
+      submenu: [
+        {
+          label: 'Reload',
+          accelerator: 'Command+R',
+          click: function () { mainWindow.restart() }
+        },
+        {
+          label: 'Toggle Full Screen',
+          accelerator: 'Ctrl+Command+F',
+          click: function () { mainWindow.setFullScreen(!mainWindow.isFullScreen()) }
+        },
+        {
+          label: 'Toggle Developer Tools',
+          accelerator: 'Alt+Command+I',
+          click: function () { mainWindow.toggleDevTools() }
+        }
+      ]
+    },
+    {
+      label: 'Window',
+      submenu: [
+        {
+          label: 'Minimize',
+          accelerator: 'Command+M',
+          selector: 'performMiniaturize:'
+        },
+        {
+          label: 'Close',
+          accelerator: 'Command+W',
+          selector: 'performClose:'
+        },
+        {
+          type: 'separator'
+        },
+        {
+          label: 'Bring All to Front',
+          selector: 'arrangeInFront:'
+        }
+      ]
+    },
+    {
+      label: 'Help',
+      submenu: [
+        {
+          label: 'Repository',
+          click: function () { require('shell').openExternal('http://github.com/jlord/git-it-electron') }
+        }
+      ]
+    }
+  ]
+  return darwinMenu
+}

--- a/main.js
+++ b/main.js
@@ -1,10 +1,15 @@
 var app = require('app')
 var BrowserWindow = require('browser-window')
 var crashReporter = require('crash-reporter')
+var Menu = require('menu')
 
-crashReporter.start()
+var darwinTemplate = require('./darwin-menu.js')
+var otherTemplate = require('./other-menu.js')
 
 var mainWindow = null
+var menu = null
+
+crashReporter.start()
 
 app.on('window-all-closed', function appQuit () {
   if (process.platform !== 'darwin') {
@@ -15,6 +20,14 @@ app.on('window-all-closed', function appQuit () {
 app.on('ready', function appReady () {
   mainWindow = new BrowserWindow({width: 800, height: 600})
   mainWindow.loadUrl('file://' + __dirname + '/index.html')
+
+  if (process.platform === 'darwin') {
+    menu = Menu.buildFromTemplate(darwinTemplate(app, mainWindow))
+    Menu.setApplicationMenu(menu)
+  } else {
+    menu = Menu.buildFromTemplate(otherTemplate(mainWindow))
+    mainWindow.setMenu(menu)
+  }
 
   mainWindow.on('closed', function winClosed () {
     mainWindow = null

--- a/other-menu.js
+++ b/other-menu.js
@@ -1,0 +1,48 @@
+module.exports = function menu (mainWindow) {
+  var otherMenu = [
+    {
+      label: '&File',
+      submenu: [
+        {
+          label: '&Open',
+          accelerator: 'Ctrl+O'
+        },
+        {
+          label: '&Close',
+          accelerator: 'Ctrl+W',
+          click: function () { mainWindow.close() }
+        }
+      ]
+    },
+    {
+      label: '&View',
+      submenu: [
+        {
+          label: '&Reload',
+          accelerator: 'Ctrl+R',
+          click: function () { mainWindow.restart() }
+        },
+        {
+          label: 'Toggle &Full Screen',
+          accelerator: 'F11',
+          click: function () { mainWindow.setFullScreen(!mainWindow.isFullScreen()) }
+        },
+        {
+          label: 'Toggle &Developer Tools',
+          accelerator: 'Alt+Ctrl+I',
+          click: function () { mainWindow.toggleDevTools() }
+        }
+      ]
+    },
+    {
+      label: 'Help',
+      submenu: [
+        {
+          label: 'Repository',
+          click: function () { require('shell').openExternal('http://github.com/jlord/git-it-electron') }
+        }
+      ]
+    }
+  ]
+  return otherMenu
+}


### PR DESCRIPTION
Since this app will be mostly website pages, having the Chrome DevTools option to be able to inspect and test changes on the fly is crutch. That's the first time I've used that word like that. So I wanted to get it in early to aid in the rest of the development.

![screen shot 2015-05-08 at 5 20 55 pm](https://cloud.githubusercontent.com/assets/1305617/7547667/9dabd2c0-f5a6-11e4-94f9-0a4d7ee79cbb.png)

A few things happened here:

- Added 2 menu files with the menu settings for two operating system types (for example, `darwin` is Mac)
- Detect which OS type is present and use the correspending menu in `main.js`

### About these commits

The menus are pulled directly from the [default ones](https://github.com/atom/electron/blob/4d9470c24e2d2e168f30846ee07dca96205185d6/atom/browser/default_app/default_app.js#L25-L234). I wanted, however, to not have such a long array in my `main.js` so I pulled them out into their own files. I changed Electron -> Git-it in some places and will leave the rest of the menu clean up until later on. 

Because this array contains functions I couldn't just convert it to JSON (as I initially tried!). So to work around this, each file is a single function that just returns this array. I then require each of the files in `main.js`, which gives me access to this function. Additionaly, some of the functions use variables that only exist in `main.js` and not their new homes, `darwin-menu.js` and `other-menu.js`, so I needed to pass these variables onto the function when I use it.  

Now when I launch the app I can press `alt+cmd+i` and get the DevTools :heart_eyes_cat: 

**Thanks** to @caged @maxogden @kevinsawicki for talking through/pointing to/helping out on this one :sparkles: 
