### PR TITLE
Add Verifying fucntionality 

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -263,3 +263,22 @@ n, v, adj {
 .u-inlineBlock {
   display: inline-block;
 }
+
+.verify-fail:before {
+  content: '😞 ';
+}
+
+.verify-pass:before {
+  content: '😀 ';
+}
+
+
+#verify-list {
+  list-style: none;
+  left-indent: none;
+  padding-left: 0;
+}
+
+.completed-challenge {
+  
+}

--- a/challenges/branches_arent_just_for_birds.html
+++ b/challenges/branches_arent_just_for_birds.html
@@ -1,21 +1,17 @@
 <!doctype html>
 <html class="no-js" lang="">
-    <head>
-        <meta charset="utf-8">
-        <meta http-equiv="X-UA-Compatible" content="IE=edge">
-        <title>Git-it Guide</title>
-        <meta name="description" content="learn git and github">
-        <meta name="viewport" content="width=device-width, initial-scale=1">
-        <link rel="icon" href="../assets/imgs/favicon.png" type="image/x-icon">
-        <link rel="stylesheet" href="../assets/css/style.css">
-        <link href='http://fonts.googleapis.com/css?family=Source+Sans+Pro:400,600,700,900' rel='stylesheet' type='text/css'>
-    </head>
-    <body>
-      <!--[if lt IE 8]>
-          <p class="browsehappy">You are using an <strong>outdated</strong> browser. Please <a href="http://browsehappy.com/">upgrade your browser</a> to improve your experience.</p>
-      <![endif]-->
-
-        <header class="site-header">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <title>Git-it Guide</title>
+    <meta name="description" content="learn git and github">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="icon" href="../assets/imgs/favicon.png" type="image/x-icon">
+    <link rel="stylesheet" href="../assets/css/style.css">
+    <link href='http://fonts.googleapis.com/css?family=Source+Sans+Pro:400,600,700,900' rel='stylesheet' type='text/css'>
+  </head>
+  <body>
+    <header class="site-header">
   <div class="nav u-posFixed">
     <div class="wrap-width u-textCenter">
       <a href="forks_and_clones.html"
@@ -27,7 +23,7 @@
       </a>
     </div>
   </div>
-  
+
   <div class="wrapper">
     <div class="u-floatLeft">
       <span class="all-caps">CHALLENGE</span>
@@ -39,9 +35,11 @@
     </div>
   </div>
 </header>
-      <div class="wrapper">
 
-        <div class="challenge">
+
+    <div class="wrapper" id="challenge-body">
+
+    <div class="challenge">
         <h2>The Challenge:</h2>
         <p>Create a new branch on your fork for your contribution.</p>
       </div>
@@ -147,7 +145,7 @@
       </div>
 
 
-        <div class="prenext">
+    <div class="prenext">
   <div class="u-floatLeft">
     <a href="forks_and_clones.html" class="u-inline-block all-caps">forks and clones
     <div>⤶ </div>
@@ -171,16 +169,18 @@
   </ul>
 </footer>
 
-      </div>
-      <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-        (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-        m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
-        ga('create', 'UA-52690821-1', 'auto');
-        ga('send', 'pageview');
+    </div>
 
-      </script>
-    </body>
+    <script>
+      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+      ga('create', 'UA-52690821-1', 'auto');
+      ga('send', 'pageview');
+    </script>
+
+  </body>
 </html>

--- a/challenges/commit_to_it.html
+++ b/challenges/commit_to_it.html
@@ -1,21 +1,17 @@
 <!doctype html>
 <html class="no-js" lang="">
-    <head>
-        <meta charset="utf-8">
-        <meta http-equiv="X-UA-Compatible" content="IE=edge">
-        <title>Git-it Guide</title>
-        <meta name="description" content="learn git and github">
-        <meta name="viewport" content="width=device-width, initial-scale=1">
-        <link rel="icon" href="../assets/imgs/favicon.png" type="image/x-icon">
-        <link rel="stylesheet" href="../assets/css/style.css">
-        <link href='http://fonts.googleapis.com/css?family=Source+Sans+Pro:400,600,700,900' rel='stylesheet' type='text/css'>
-    </head>
-    <body>
-      <!--[if lt IE 8]>
-          <p class="browsehappy">You are using an <strong>outdated</strong> browser. Please <a href="http://browsehappy.com/">upgrade your browser</a> to improve your experience.</p>
-      <![endif]-->
-
-        <header class="site-header">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <title>Git-it Guide</title>
+    <meta name="description" content="learn git and github">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="icon" href="../assets/imgs/favicon.png" type="image/x-icon">
+    <link rel="stylesheet" href="../assets/css/style.css">
+    <link href='http://fonts.googleapis.com/css?family=Source+Sans+Pro:400,600,700,900' rel='stylesheet' type='text/css'>
+  </head>
+  <body>
+    <header class="site-header">
   <div class="nav u-posFixed">
     <div class="wrap-width u-textCenter">
       <a href="repository.html"
@@ -27,7 +23,7 @@
       </a>
     </div>
   </div>
-  
+
   <div class="wrapper">
     <div class="u-floatLeft">
       <span class="all-caps">CHALLENGE</span>
@@ -39,9 +35,11 @@
     </div>
   </div>
 </header>
-      <div class="wrapper">
 
-              <div class="challenge">
+
+    <div class="wrapper" id="challenge-body">
+
+          <div class="challenge">
         <h2>The Challenge:</h2>
         <p>Create a file in your new repository, add something to that file and
           commit those changes to Git.</p>
@@ -102,7 +100,7 @@
       </div>
 
 
-        <div class="prenext">
+    <div class="prenext">
   <div class="u-floatLeft">
     <a href="repository.html" class="u-inline-block all-caps">repository
     <div>⤶ </div>
@@ -126,16 +124,18 @@
   </ul>
 </footer>
 
-      </div>
-      <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-        (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-        m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
-        ga('create', 'UA-52690821-1', 'auto');
-        ga('send', 'pageview');
+    </div>
 
-      </script>
-    </body>
+    <script>
+      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+      ga('create', 'UA-52690821-1', 'auto');
+      ga('send', 'pageview');
+    </script>
+
+  </body>
 </html>

--- a/challenges/forks_and_clones.html
+++ b/challenges/forks_and_clones.html
@@ -1,21 +1,17 @@
 <!doctype html>
 <html class="no-js" lang="">
-    <head>
-        <meta charset="utf-8">
-        <meta http-equiv="X-UA-Compatible" content="IE=edge">
-        <title>Git-it Guide</title>
-        <meta name="description" content="learn git and github">
-        <meta name="viewport" content="width=device-width, initial-scale=1">
-        <link rel="icon" href="../assets/imgs/favicon.png" type="image/x-icon">
-        <link rel="stylesheet" href="../assets/css/style.css">
-        <link href='http://fonts.googleapis.com/css?family=Source+Sans+Pro:400,600,700,900' rel='stylesheet' type='text/css'>
-    </head>
-    <body>
-      <!--[if lt IE 8]>
-          <p class="browsehappy">You are using an <strong>outdated</strong> browser. Please <a href="http://browsehappy.com/">upgrade your browser</a> to improve your experience.</p>
-      <![endif]-->
-
-        <header class="site-header">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <title>Git-it Guide</title>
+    <meta name="description" content="learn git and github">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="icon" href="../assets/imgs/favicon.png" type="image/x-icon">
+    <link rel="stylesheet" href="../assets/css/style.css">
+    <link href='http://fonts.googleapis.com/css?family=Source+Sans+Pro:400,600,700,900' rel='stylesheet' type='text/css'>
+  </head>
+  <body>
+    <header class="site-header">
   <div class="nav u-posFixed">
     <div class="wrap-width u-textCenter">
       <a href="remote_control.html"
@@ -27,7 +23,7 @@
       </a>
     </div>
   </div>
-  
+
   <div class="wrapper">
     <div class="u-floatLeft">
       <span class="all-caps">CHALLENGE</span>
@@ -39,9 +35,11 @@
     </div>
   </div>
 </header>
-      <div class="wrapper">
 
-             <div class="challenge">
+
+    <div class="wrapper" id="challenge-body">
+
+         <div class="challenge">
         <h2>The Challenge:</h2>
         <p>Fork a project from GitHub.com and clone it locally.</p>
       </div>
@@ -115,7 +113,7 @@
       </div>
 
 
-        <div class="prenext">
+    <div class="prenext">
   <div class="u-floatLeft">
     <a href="remote_control.html" class="u-inline-block all-caps">remote control
     <div>⤶ </div>
@@ -139,16 +137,18 @@
   </ul>
 </footer>
 
-      </div>
-      <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-        (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-        m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
-        ga('create', 'UA-52690821-1', 'auto');
-        ga('send', 'pageview');
+    </div>
 
-      </script>
-    </body>
+    <script>
+      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+      ga('create', 'UA-52690821-1', 'auto');
+      ga('send', 'pageview');
+    </script>
+
+  </body>
 </html>

--- a/challenges/get_git.html
+++ b/challenges/get_git.html
@@ -27,7 +27,7 @@
       </a>
     </div>
   </div>
-  
+
   <div class="wrapper">
     <div class="u-floatLeft">
       <span class="all-caps">CHALLENGE</span>
@@ -39,9 +39,9 @@
     </div>
   </div>
 </header>
-      <div class="wrapper">
+      <div class="wrapper" id="challenge-body">
 
-                    <div class="challenge">
+                    <div class="challenge" id="challenge-desc">
         <h2>The Challenge:</h2>
         <p>Install Git on your computer and configure your name and email.</p>
       </div>
@@ -95,8 +95,15 @@
       <p><code>$ git config --global user.email "&#60;youremail@example.com&#62;"</code></p>
 
       <div class="verify">
-        <h3>Verify with </h3> <code>git-it verify </code><br>
-        <h3>Go to the next challenge </h3> <code>git-it</code>
+        <button id='verify-challenge'>VERIFY</button>
+        <h5>Results:</h5>
+        <ul id="verify-list">
+        </ul>
+        <!-- <ul class="verify-list">
+          <li class="verify-fail">Email Added!</li>
+          <li class="verify-pass">Name Added!</li>
+          <li class="verify-pass">Found Git installed.</li>
+        </ul> -->
       </div>
 
       <div id="git-tips">
@@ -105,7 +112,6 @@
       to signify that the line is <strong>command line</strong> code (see the code snippets above). You don't actually
       type the <code>$</code> in though, only type what comes after. For instance, to run the verify command above, you're actually going to type <code>git-it verify</code> into terminal.</p>
       </div>
-
 
         <div class="prenext">
   <div class="u-floatLeft">
@@ -131,16 +137,112 @@
   </ul>
 </footer>
 
-      </div>
-      <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-        (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-        m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+  </div>
+  <script>
+    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
-        ga('create', 'UA-52690821-1', 'auto');
-        ga('send', 'pageview');
+    ga('create', 'UA-52690821-1', 'auto');
+    ga('send', 'pageview');
 
-      </script>
-    </body>
+  </script>
+
+  <script>
+  var exec = require('child_process').exec
+  var fs = require('fs')
+
+  var userData = require('../data.json')
+
+  var currentChallenge = 'get_git'
+
+  var verifyButton = document.getElementById("verify-challenge")
+  var ul = document.getElementById('verify-list')
+
+  console.log("dir", __dirname)
+
+  verifyButton.addEventListener('click', function clicked (event) {
+    ul.innerHTML = ''
+
+    var total = 3
+    var counter = 0
+
+    exec('git config user.email', function(err, stdout, stderr) {
+      var email = stdout.trim()
+      if (email === "") {
+        addToList("No email found.", false)
+        console.error("No email found.")
+      }
+      else {
+        counter++
+        addToList("Email Added", true)
+        console.log("Email Added!")
+        exec('git config user.name', function(err, stdout, stderr) {
+          var name = stdout.trim()
+          if (name === "") {
+            addToList("No name found.", false)
+            console.error("No name found.")
+          }
+          else {
+            counter++
+            addToList("Name Added!", true)
+            console.log("Name Added!")
+            exec('git --version', function(err, stdout, stdrr) {
+              var gitOutput = stdout.trim()
+
+              if (gitOutput.match("git version")) {
+                counter++
+                addToList("Found Git installed.", true)
+                console.log("Found Git installed.")
+              }
+              else {
+                addToList("Found no Git installed.", false)
+                console.log("Found no Git installed.")
+              }
+
+              if (counter === total) {
+                markChallengeCompleted()
+                writeData()
+                // if they pass all, write to userData
+              }
+
+            })
+          }
+        })
+      }
+    })
+  })
+
+  function addToList (message, status) {
+    var li = document.createElement("li")
+    var newContent = document.createTextNode(message)
+    li.appendChild(newContent)
+    if (status) {
+      li.classList.add("verify-pass")
+    } else li.classList.add("verify-fail")
+    ul.appendChild(li)
+    // potentially do this with domify and push
+    // into an array and write once
+  }
+
+  function markChallengeCompleted () {
+    var challengeBody = document.getElementById("challenge-body")
+    var challengeDesc = document.getElementById("challenge-desc")
+    var div = document.createElement("h2")
+    var newContent = document.createTextNode("COMPLETED!")
+    div.appendChild(newContent)
+    div.classList.add("completed-challenge")
+    challengeBody.insertBefore(div, challengeDesc)
+  }
+
+  function writeData () {
+    console.log("Data", userData)
+    userData.get_git.completed = true
+    console.log("Current", userData.get_git)
+    fs.writeFileSync('./data.json', JSON.stringify(userData, null, 2))
+  }
+
+  </script>
+  </body>
 </html>

--- a/challenges/get_git.html
+++ b/challenges/get_git.html
@@ -1,21 +1,17 @@
 <!doctype html>
 <html class="no-js" lang="">
-    <head>
-        <meta charset="utf-8">
-        <meta http-equiv="X-UA-Compatible" content="IE=edge">
-        <title>Git-it Guide</title>
-        <meta name="description" content="learn git and github">
-        <meta name="viewport" content="width=device-width, initial-scale=1">
-        <link rel="icon" href="../assets/imgs/favicon.png" type="image/x-icon">
-        <link rel="stylesheet" href="../assets/css/style.css">
-        <link href='http://fonts.googleapis.com/css?family=Source+Sans+Pro:400,600,700,900' rel='stylesheet' type='text/css'>
-    </head>
-    <body>
-      <!--[if lt IE 8]>
-          <p class="browsehappy">You are using an <strong>outdated</strong> browser. Please <a href="http://browsehappy.com/">upgrade your browser</a> to improve your experience.</p>
-      <![endif]-->
-
-        <header class="site-header">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <title>Git-it Guide</title>
+    <meta name="description" content="learn git and github">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="icon" href="../assets/imgs/favicon.png" type="image/x-icon">
+    <link rel="stylesheet" href="../assets/css/style.css">
+    <link href='http://fonts.googleapis.com/css?family=Source+Sans+Pro:400,600,700,900' rel='stylesheet' type='text/css'>
+  </head>
+  <body>
+    <header class="site-header">
   <div class="nav u-posFixed">
     <div class="wrap-width u-textCenter">
       <a href="../index.html"
@@ -39,81 +35,90 @@
     </div>
   </div>
 </header>
-      <div class="wrapper" id="challenge-body">
 
-                    <div class="challenge" id="challenge-desc">
-        <h2>The Challenge:</h2>
-        <p>Install Git on your computer and configure your name and email.</p>
-      </div>
 
-      <h2>Git</h2>
+    <div class="wrapper" id="challenge-body">
 
-      <p>Git is <strong>open source software</strong> (free for anyone to use) written
-        by Linus Torvalds who also wrote the Linux operating system. </p>
-      <p>It is a program for keeping track of changes over time, known in
-        programming as <strong>version control</strong>.</p>
+    <div id="challenge-desc" class="challenge">
+  <h2>The Challenge:</h2>
+  <p>Install Git on your computer and configure your name and email.</p>
+</div>
 
-      <h2>Step: Install Git</h2>
+<h2>Git</h2>
 
-      <ul>
-        <li><strong>Windows</strong>: It's recommended to download GitHub for Windows,
-        which includes Git and has an easier install:
-        <a href="http://windows.github.com" target="_blank">windows.github.com</a>. Use the <strong>Git Shell</strong> for your terminal.</li>
+<p>Git is <strong>open source software</strong> (free for anyone to use) written
+  by Linus Torvalds who also wrote the Linux operating system. </p>
+<p>It is a program for keeping track of changes over time, known in
+  programming as <strong>version control</strong>.</p>
 
-        <li><strong>Mac</strong>: You can also download GitHub for Mac, which includes
-        Git, <a href="http://mac.github.com/" target="_blank">mac.github.com</a> (from Preferences, select
-        the command line tools install), or
-          <ul>
-            <li>download Git by itself at:
-            <a href="http://git-scm.com/downloads" target="_blank">git-scm.com/downloads</a> and follow the installation instructions.</li>
-          </ul>
-        </li>
-      </ul>
+<h2>Step: Install Git</h2>
 
-      <p>Git isn't like other programs on your computer. You'll likely not
-      see an icon on your desktop, but it will always be available to you
-      and you'll be able to access it at anytime from your
-      terminal (which you're using in Git-it!) or Git desktop applications (like GitHub for Mac or Windows).</p>
+<ul>
+  <li><strong>Windows</strong>: It's recommended to download GitHub for Windows,
+  which includes Git and has an easier install:
+  <a href="http://windows.github.com" target="_blank">windows.github.com</a>. Use the <strong>Git Shell</strong> for your terminal.</li>
 
-      <h2>Step: Configure Git</h2>
-      <p>Once it is installed, open <strong>terminal</strong> (aka Bash, aka Shell, aka Prompt).
-      You can verify that it's really there by typing:</p>
+  <li><strong>Mac</strong>: You can also download GitHub for Mac, which includes
+  Git, <a href="http://mac.github.com/" target="_blank">mac.github.com</a> (from Preferences, select
+  the command line tools install), or
+    <ul>
+      <li>download Git by itself at:
+      <a href="http://git-scm.com/downloads" target="_blank">git-scm.com/downloads</a> and follow the installation instructions.</li>
+    </ul>
+  </li>
+</ul>
 
-      <p><code>$ git --version </code></p>
+<p>Git isn't like other programs on your computer. You'll likely not
+see an icon on your desktop, but it will always be available to you
+and you'll be able to access it at anytime from your
+terminal (which you're using in Git-it!) or Git desktop applications (like GitHub for Mac or Windows).</p>
 
-      <p>This will return the version of Git that you're running and look something like this:</p>
+<h2>Step: Configure Git</h2>
+<p>Once it is installed, open <strong>terminal</strong> (aka Bash, aka Shell, aka Prompt).
+You can verify that it's really there by typing:</p>
 
-      <p><code>git version 1.9.1</code></p>
+<p><code>$ git --version </code></p>
 
-      <p>(Any version <code>1.7.10</code> or higher is fine.)</p>
+<p>This will return the version of Git that you're running and look something like this:</p>
 
-      <p>Next, configure Git so it knows who to associate your changes to:</p>
+<p><code>git version 1.9.1</code></p>
 
-      <p>Set your name:</p>
-      <p><code>$ git config --global user.name "&#60;Your Name&#62;"</code></p>
-      <p>Now set your email:</p>
-      <p><code>$ git config --global user.email "&#60;youremail@example.com&#62;"</code></p>
+<p>(Any version <code>1.7.10</code> or higher is fine.)</p>
 
-      <div class="verify">
-        <button id='verify-challenge'>VERIFY</button>
-        <h5>Results:</h5>
-        <ul id="verify-list">
-        </ul>
-        <!-- <ul class="verify-list">
-          <li class="verify-fail">Email Added!</li>
-          <li class="verify-pass">Name Added!</li>
-          <li class="verify-pass">Found Git installed.</li>
-        </ul> -->
-      </div>
+<p>Next, configure Git so it knows who to associate your changes to:</p>
 
-      <div id="git-tips">
-        <h2>Tips</h2>
-        <p>Dollar signs <code>$</code> are often used in programming documentation
-      to signify that the line is <strong>command line</strong> code (see the code snippets above). You don't actually
-      type the <code>$</code> in though, only type what comes after. For instance, to run the verify command above, you're actually going to type <code>git-it verify</code> into terminal.</p>
-      </div>
+<p>Set your name:</p>
+<p><code>$ git config --global user.name "&#60;Your Name&#62;"</code></p>
+<p>Now set your email:</p>
+<p><code>$ git config --global user.email "&#60;youremail@example.com&#62;"</code></p>
 
-        <div class="prenext">
+<div class="verify">
+  <button id='verify-challenge'>VERIFY</button>
+  <ul id="verify-list">
+  </ul>
+</div>
+
+<div id="git-tips">
+  <h2>Tips</h2>
+  <p>Dollar signs <code>$</code> are often used in programming documentation
+to signify that the line is <strong>command line</strong> code (see the code snippets above). You don't actually
+type the <code>$</code> in though, only type what comes after. For instance, to run the verify command above, you're actually going to type <code>git-it verify</code> into terminal.</p>
+</div>
+
+<script>
+  var verifyChallenge = require('../verify/get_git.js')
+
+  var verifyButton = document.getElementById('verify-challenge')
+  var ul = document.getElementById('verify-list')
+
+  verifyButton.addEventListener('click', function clicked (event) {
+    ul.innerHTML = ''
+    verifyChallenge()
+  })
+</script>
+
+
+    <div class="prenext">
   <div class="u-floatLeft">
     <a href="../index.html" class="u-inline-block all-caps">All Challenges
     <div>⤶ </div>
@@ -137,112 +142,18 @@
   </ul>
 </footer>
 
-  </div>
-  <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
-    ga('create', 'UA-52690821-1', 'auto');
-    ga('send', 'pageview');
+    </div>
 
-  </script>
+    <script>
+      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
-  <script>
-  var exec = require('child_process').exec
-  var fs = require('fs')
+      ga('create', 'UA-52690821-1', 'auto');
+      ga('send', 'pageview');
+    </script>
 
-  var userData = require('../data.json')
-
-  var currentChallenge = 'get_git'
-
-  var verifyButton = document.getElementById("verify-challenge")
-  var ul = document.getElementById('verify-list')
-
-  console.log("dir", __dirname)
-
-  verifyButton.addEventListener('click', function clicked (event) {
-    ul.innerHTML = ''
-
-    var total = 3
-    var counter = 0
-
-    exec('git config user.email', function(err, stdout, stderr) {
-      var email = stdout.trim()
-      if (email === "") {
-        addToList("No email found.", false)
-        console.error("No email found.")
-      }
-      else {
-        counter++
-        addToList("Email Added", true)
-        console.log("Email Added!")
-        exec('git config user.name', function(err, stdout, stderr) {
-          var name = stdout.trim()
-          if (name === "") {
-            addToList("No name found.", false)
-            console.error("No name found.")
-          }
-          else {
-            counter++
-            addToList("Name Added!", true)
-            console.log("Name Added!")
-            exec('git --version', function(err, stdout, stdrr) {
-              var gitOutput = stdout.trim()
-
-              if (gitOutput.match("git version")) {
-                counter++
-                addToList("Found Git installed.", true)
-                console.log("Found Git installed.")
-              }
-              else {
-                addToList("Found no Git installed.", false)
-                console.log("Found no Git installed.")
-              }
-
-              if (counter === total) {
-                markChallengeCompleted()
-                writeData()
-                // if they pass all, write to userData
-              }
-
-            })
-          }
-        })
-      }
-    })
-  })
-
-  function addToList (message, status) {
-    var li = document.createElement("li")
-    var newContent = document.createTextNode(message)
-    li.appendChild(newContent)
-    if (status) {
-      li.classList.add("verify-pass")
-    } else li.classList.add("verify-fail")
-    ul.appendChild(li)
-    // potentially do this with domify and push
-    // into an array and write once
-  }
-
-  function markChallengeCompleted () {
-    var challengeBody = document.getElementById("challenge-body")
-    var challengeDesc = document.getElementById("challenge-desc")
-    var div = document.createElement("h2")
-    var newContent = document.createTextNode("COMPLETED!")
-    div.appendChild(newContent)
-    div.classList.add("completed-challenge")
-    challengeBody.insertBefore(div, challengeDesc)
-  }
-
-  function writeData () {
-    console.log("Data", userData)
-    userData.get_git.completed = true
-    console.log("Current", userData.get_git)
-    fs.writeFileSync('./data.json', JSON.stringify(userData, null, 2))
-  }
-
-  </script>
   </body>
 </html>

--- a/challenges/githubbin.html
+++ b/challenges/githubbin.html
@@ -1,21 +1,17 @@
 <!doctype html>
 <html class="no-js" lang="">
-    <head>
-        <meta charset="utf-8">
-        <meta http-equiv="X-UA-Compatible" content="IE=edge">
-        <title>Git-it Guide</title>
-        <meta name="description" content="learn git and github">
-        <meta name="viewport" content="width=device-width, initial-scale=1">
-        <link rel="icon" href="../assets/imgs/favicon.png" type="image/x-icon">
-        <link rel="stylesheet" href="../assets/css/style.css">
-        <link href='http://fonts.googleapis.com/css?family=Source+Sans+Pro:400,600,700,900' rel='stylesheet' type='text/css'>
-    </head>
-    <body>
-      <!--[if lt IE 8]>
-          <p class="browsehappy">You are using an <strong>outdated</strong> browser. Please <a href="http://browsehappy.com/">upgrade your browser</a> to improve your experience.</p>
-      <![endif]-->
-
-        <header class="site-header">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <title>Git-it Guide</title>
+    <meta name="description" content="learn git and github">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="icon" href="../assets/imgs/favicon.png" type="image/x-icon">
+    <link rel="stylesheet" href="../assets/css/style.css">
+    <link href='http://fonts.googleapis.com/css?family=Source+Sans+Pro:400,600,700,900' rel='stylesheet' type='text/css'>
+  </head>
+  <body>
+    <header class="site-header">
   <div class="nav u-posFixed">
     <div class="wrap-width u-textCenter">
       <a href="commit_to_it.html"
@@ -27,7 +23,7 @@
       </a>
     </div>
   </div>
-  
+
   <div class="wrapper">
     <div class="u-floatLeft">
       <span class="all-caps">CHALLENGE</span>
@@ -39,9 +35,11 @@
     </div>
   </div>
 </header>
-      <div class="wrapper">
 
-              <div class="challenge">
+
+    <div class="wrapper" id="challenge-body">
+
+          <div class="challenge">
         <h2>The Challenge:</h2>
         <p>Create a GitHub account, add username to your Git config.</p>
       </div>
@@ -84,7 +82,7 @@
       </div>
 
 
-        <div class="prenext">
+    <div class="prenext">
   <div class="u-floatLeft">
     <a href="commit_to_it.html" class="u-inline-block all-caps">commit to it
     <div>⤶ </div>
@@ -108,16 +106,18 @@
   </ul>
 </footer>
 
-      </div>
-      <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-        (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-        m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
-        ga('create', 'UA-52690821-1', 'auto');
-        ga('send', 'pageview');
+    </div>
 
-      </script>
-    </body>
+    <script>
+      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+      ga('create', 'UA-52690821-1', 'auto');
+      ga('send', 'pageview');
+    </script>
+
+  </body>
 </html>

--- a/challenges/its_a_small_world.html
+++ b/challenges/its_a_small_world.html
@@ -1,21 +1,17 @@
 <!doctype html>
 <html class="no-js" lang="">
-    <head>
-        <meta charset="utf-8">
-        <meta http-equiv="X-UA-Compatible" content="IE=edge">
-        <title>Git-it Guide</title>
-        <meta name="description" content="learn git and github">
-        <meta name="viewport" content="width=device-width, initial-scale=1">
-        <link rel="icon" href="../assets/imgs/favicon.png" type="image/x-icon">
-        <link rel="stylesheet" href="../assets/css/style.css">
-        <link href='http://fonts.googleapis.com/css?family=Source+Sans+Pro:400,600,700,900' rel='stylesheet' type='text/css'>
-    </head>
-    <body>
-      <!--[if lt IE 8]>
-          <p class="browsehappy">You are using an <strong>outdated</strong> browser. Please <a href="http://browsehappy.com/">upgrade your browser</a> to improve your experience.</p>
-      <![endif]-->
-
-        <header class="site-header">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <title>Git-it Guide</title>
+    <meta name="description" content="learn git and github">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="icon" href="../assets/imgs/favicon.png" type="image/x-icon">
+    <link rel="stylesheet" href="../assets/css/style.css">
+    <link href='http://fonts.googleapis.com/css?family=Source+Sans+Pro:400,600,700,900' rel='stylesheet' type='text/css'>
+  </head>
+  <body>
+    <header class="site-header">
   <div class="nav u-posFixed">
     <div class="wrap-width u-textCenter">
       <a href="branches_arent_just_for_birds.html"
@@ -27,7 +23,7 @@
       </a>
     </div>
   </div>
-  
+
   <div class="wrapper">
     <div class="u-floatLeft">
       <span class="all-caps">CHALLENGE</span>
@@ -39,9 +35,11 @@
     </div>
   </div>
 </header>
-      <div class="wrapper">
 
-              <div class="challenge">
+
+    <div class="wrapper" id="challenge-body">
+
+          <div class="challenge">
         <h2>The Challenge:</h2>
         <p>Add a collaborator to your project.</p>
       </div>
@@ -72,7 +70,7 @@
       </div>
 
 
-        <div class="prenext">
+    <div class="prenext">
   <div class="u-floatLeft">
     <a href="branches_arent_just_for_birds.html" class="u-inline-block all-caps">branches aren&#x27;t just for birds
     <div>⤶ </div>
@@ -96,16 +94,18 @@
   </ul>
 </footer>
 
-      </div>
-      <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-        (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-        m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
-        ga('create', 'UA-52690821-1', 'auto');
-        ga('send', 'pageview');
+    </div>
 
-      </script>
-    </body>
+    <script>
+      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+      ga('create', 'UA-52690821-1', 'auto');
+      ga('send', 'pageview');
+    </script>
+
+  </body>
 </html>

--- a/challenges/merge_tada.html
+++ b/challenges/merge_tada.html
@@ -1,21 +1,17 @@
 <!doctype html>
 <html class="no-js" lang="">
-    <head>
-        <meta charset="utf-8">
-        <meta http-equiv="X-UA-Compatible" content="IE=edge">
-        <title>Git-it Guide</title>
-        <meta name="description" content="learn git and github">
-        <meta name="viewport" content="width=device-width, initial-scale=1">
-        <link rel="icon" href="../assets/imgs/favicon.png" type="image/x-icon">
-        <link rel="stylesheet" href="../assets/css/style.css">
-        <link href='http://fonts.googleapis.com/css?family=Source+Sans+Pro:400,600,700,900' rel='stylesheet' type='text/css'>
-    </head>
-    <body>
-      <!--[if lt IE 8]>
-          <p class="browsehappy">You are using an <strong>outdated</strong> browser. Please <a href="http://browsehappy.com/">upgrade your browser</a> to improve your experience.</p>
-      <![endif]-->
-
-        <header class="site-header">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <title>Git-it Guide</title>
+    <meta name="description" content="learn git and github">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="icon" href="../assets/imgs/favicon.png" type="image/x-icon">
+    <link rel="stylesheet" href="../assets/css/style.css">
+    <link href='http://fonts.googleapis.com/css?family=Source+Sans+Pro:400,600,700,900' rel='stylesheet' type='text/css'>
+  </head>
+  <body>
+    <header class="site-header">
   <div class="nav u-posFixed">
     <div class="wrap-width u-textCenter">
       <a href="requesting_you_pull_please.html"
@@ -27,7 +23,7 @@
       </a>
     </div>
   </div>
-  
+
   <div class="wrapper">
     <div class="u-floatLeft">
       <span class="all-caps">CHALLENGE</span>
@@ -39,9 +35,11 @@
     </div>
   </div>
 </header>
-      <div class="wrapper">
 
-              <div class="challenge">
+
+    <div class="wrapper" id="challenge-body">
+
+          <div class="challenge">
         <h2>The Challenge:</h2>
         <p>Merge your branch locally, delete old branch and pull from upstream for much win!</p>
        </div>
@@ -106,7 +104,7 @@
       </div>
 
 
-        <div class="prenext">
+    <div class="prenext">
   <div class="u-floatLeft">
     <a href="requesting_you_pull_please.html" class="u-inline-block all-caps">requesting you pull please
     <div>⤶ </div>
@@ -130,16 +128,18 @@
   </ul>
 </footer>
 
-      </div>
-      <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-        (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-        m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
-        ga('create', 'UA-52690821-1', 'auto');
-        ga('send', 'pageview');
+    </div>
 
-      </script>
-    </body>
+    <script>
+      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+      ga('create', 'UA-52690821-1', 'auto');
+      ga('send', 'pageview');
+    </script>
+
+  </body>
 </html>

--- a/challenges/pull_never_out_of_date.html
+++ b/challenges/pull_never_out_of_date.html
@@ -1,21 +1,17 @@
 <!doctype html>
 <html class="no-js" lang="">
-    <head>
-        <meta charset="utf-8">
-        <meta http-equiv="X-UA-Compatible" content="IE=edge">
-        <title>Git-it Guide</title>
-        <meta name="description" content="learn git and github">
-        <meta name="viewport" content="width=device-width, initial-scale=1">
-        <link rel="icon" href="../assets/imgs/favicon.png" type="image/x-icon">
-        <link rel="stylesheet" href="../assets/css/style.css">
-        <link href='http://fonts.googleapis.com/css?family=Source+Sans+Pro:400,600,700,900' rel='stylesheet' type='text/css'>
-    </head>
-    <body>
-      <!--[if lt IE 8]>
-          <p class="browsehappy">You are using an <strong>outdated</strong> browser. Please <a href="http://browsehappy.com/">upgrade your browser</a> to improve your experience.</p>
-      <![endif]-->
-
-        <header class="site-header">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <title>Git-it Guide</title>
+    <meta name="description" content="learn git and github">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="icon" href="../assets/imgs/favicon.png" type="image/x-icon">
+    <link rel="stylesheet" href="../assets/css/style.css">
+    <link href='http://fonts.googleapis.com/css?family=Source+Sans+Pro:400,600,700,900' rel='stylesheet' type='text/css'>
+  </head>
+  <body>
+    <header class="site-header">
   <div class="nav u-posFixed">
     <div class="wrap-width u-textCenter">
       <a href="its_a_small_world.html"
@@ -27,7 +23,7 @@
       </a>
     </div>
   </div>
-  
+
   <div class="wrapper">
     <div class="u-floatLeft">
       <span class="all-caps">CHALLENGE</span>
@@ -39,9 +35,11 @@
     </div>
   </div>
 </header>
-      <div class="wrapper">
 
-              <div class="challenge">
+
+    <div class="wrapper" id="challenge-body">
+
+          <div class="challenge">
         <h2>The Challenge:</h2>
         <p>Keep your file up to date by pulling in changes from collaborators.</p>
       </div>
@@ -85,7 +83,7 @@
       </div>
 
 
-        <div class="prenext">
+    <div class="prenext">
   <div class="u-floatLeft">
     <a href="its_a_small_world.html" class="u-inline-block all-caps">it&#x27;s a small world
     <div>⤶ </div>
@@ -109,16 +107,18 @@
   </ul>
 </footer>
 
-      </div>
-      <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-        (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-        m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
-        ga('create', 'UA-52690821-1', 'auto');
-        ga('send', 'pageview');
+    </div>
 
-      </script>
-    </body>
+    <script>
+      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+      ga('create', 'UA-52690821-1', 'auto');
+      ga('send', 'pageview');
+    </script>
+
+  </body>
 </html>

--- a/challenges/remote_control.html
+++ b/challenges/remote_control.html
@@ -1,21 +1,17 @@
 <!doctype html>
 <html class="no-js" lang="">
-    <head>
-        <meta charset="utf-8">
-        <meta http-equiv="X-UA-Compatible" content="IE=edge">
-        <title>Git-it Guide</title>
-        <meta name="description" content="learn git and github">
-        <meta name="viewport" content="width=device-width, initial-scale=1">
-        <link rel="icon" href="../assets/imgs/favicon.png" type="image/x-icon">
-        <link rel="stylesheet" href="../assets/css/style.css">
-        <link href='http://fonts.googleapis.com/css?family=Source+Sans+Pro:400,600,700,900' rel='stylesheet' type='text/css'>
-    </head>
-    <body>
-      <!--[if lt IE 8]>
-          <p class="browsehappy">You are using an <strong>outdated</strong> browser. Please <a href="http://browsehappy.com/">upgrade your browser</a> to improve your experience.</p>
-      <![endif]-->
-
-        <header class="site-header">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <title>Git-it Guide</title>
+    <meta name="description" content="learn git and github">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="icon" href="../assets/imgs/favicon.png" type="image/x-icon">
+    <link rel="stylesheet" href="../assets/css/style.css">
+    <link href='http://fonts.googleapis.com/css?family=Source+Sans+Pro:400,600,700,900' rel='stylesheet' type='text/css'>
+  </head>
+  <body>
+    <header class="site-header">
   <div class="nav u-posFixed">
     <div class="wrap-width u-textCenter">
       <a href="githubbin.html"
@@ -27,7 +23,7 @@
       </a>
     </div>
   </div>
-  
+
   <div class="wrapper">
     <div class="u-floatLeft">
       <span class="all-caps">CHALLENGE</span>
@@ -39,9 +35,11 @@
     </div>
   </div>
 </header>
-      <div class="wrapper">
 
-                      <div class="challenge">
+
+    <div class="wrapper" id="challenge-body">
+
+                  <div class="challenge">
       <h2>The Challenge:</h2>
       <p>Connect your local and remote repositories and push changes.</p>
       </div>
@@ -152,7 +150,7 @@
     </div>
 
 
-        <div class="prenext">
+    <div class="prenext">
   <div class="u-floatLeft">
     <a href="githubbin.html" class="u-inline-block all-caps">GitHubbin
     <div>⤶ </div>
@@ -176,16 +174,18 @@
   </ul>
 </footer>
 
-      </div>
-      <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-        (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-        m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
-        ga('create', 'UA-52690821-1', 'auto');
-        ga('send', 'pageview');
+    </div>
 
-      </script>
-    </body>
+    <script>
+      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+      ga('create', 'UA-52690821-1', 'auto');
+      ga('send', 'pageview');
+    </script>
+
+  </body>
 </html>

--- a/challenges/repository.html
+++ b/challenges/repository.html
@@ -1,21 +1,17 @@
 <!doctype html>
 <html class="no-js" lang="">
-    <head>
-        <meta charset="utf-8">
-        <meta http-equiv="X-UA-Compatible" content="IE=edge">
-        <title>Git-it Guide</title>
-        <meta name="description" content="learn git and github">
-        <meta name="viewport" content="width=device-width, initial-scale=1">
-        <link rel="icon" href="../assets/imgs/favicon.png" type="image/x-icon">
-        <link rel="stylesheet" href="../assets/css/style.css">
-        <link href='http://fonts.googleapis.com/css?family=Source+Sans+Pro:400,600,700,900' rel='stylesheet' type='text/css'>
-    </head>
-    <body>
-      <!--[if lt IE 8]>
-          <p class="browsehappy">You are using an <strong>outdated</strong> browser. Please <a href="http://browsehappy.com/">upgrade your browser</a> to improve your experience.</p>
-      <![endif]-->
-
-        <header class="site-header">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <title>Git-it Guide</title>
+    <meta name="description" content="learn git and github">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="icon" href="../assets/imgs/favicon.png" type="image/x-icon">
+    <link rel="stylesheet" href="../assets/css/style.css">
+    <link href='http://fonts.googleapis.com/css?family=Source+Sans+Pro:400,600,700,900' rel='stylesheet' type='text/css'>
+  </head>
+  <body>
+    <header class="site-header">
   <div class="nav u-posFixed">
     <div class="wrap-width u-textCenter">
       <a href="get_git.html"
@@ -27,7 +23,7 @@
       </a>
     </div>
   </div>
-  
+
   <div class="wrapper">
     <div class="u-floatLeft">
       <span class="all-caps">CHALLENGE</span>
@@ -39,9 +35,11 @@
     </div>
   </div>
 </header>
-      <div class="wrapper">
 
-            <div class="challenge">
+
+    <div class="wrapper" id="challenge-body">
+
+        <div class="challenge">
       <h2>The Challenge:</h2>
       <p>Create a new repository on your computer.</p>
     </div>
@@ -105,7 +103,7 @@
     </div>
 
 
-        <div class="prenext">
+    <div class="prenext">
   <div class="u-floatLeft">
     <a href="get_git.html" class="u-inline-block all-caps">get git
     <div>⤶ </div>
@@ -129,16 +127,18 @@
   </ul>
 </footer>
 
-      </div>
-      <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-        (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-        m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
-        ga('create', 'UA-52690821-1', 'auto');
-        ga('send', 'pageview');
+    </div>
 
-      </script>
-    </body>
+    <script>
+      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+      ga('create', 'UA-52690821-1', 'auto');
+      ga('send', 'pageview');
+    </script>
+
+  </body>
 </html>

--- a/challenges/requesting_you_pull_please.html
+++ b/challenges/requesting_you_pull_please.html
@@ -1,21 +1,17 @@
 <!doctype html>
 <html class="no-js" lang="">
-    <head>
-        <meta charset="utf-8">
-        <meta http-equiv="X-UA-Compatible" content="IE=edge">
-        <title>Git-it Guide</title>
-        <meta name="description" content="learn git and github">
-        <meta name="viewport" content="width=device-width, initial-scale=1">
-        <link rel="icon" href="../assets/imgs/favicon.png" type="image/x-icon">
-        <link rel="stylesheet" href="../assets/css/style.css">
-        <link href='http://fonts.googleapis.com/css?family=Source+Sans+Pro:400,600,700,900' rel='stylesheet' type='text/css'>
-    </head>
-    <body>
-      <!--[if lt IE 8]>
-          <p class="browsehappy">You are using an <strong>outdated</strong> browser. Please <a href="http://browsehappy.com/">upgrade your browser</a> to improve your experience.</p>
-      <![endif]-->
-
-        <header class="site-header">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <title>Git-it Guide</title>
+    <meta name="description" content="learn git and github">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="icon" href="../assets/imgs/favicon.png" type="image/x-icon">
+    <link rel="stylesheet" href="../assets/css/style.css">
+    <link href='http://fonts.googleapis.com/css?family=Source+Sans+Pro:400,600,700,900' rel='stylesheet' type='text/css'>
+  </head>
+  <body>
+    <header class="site-header">
   <div class="nav u-posFixed">
     <div class="wrap-width u-textCenter">
       <a href="pull_never_out_of_date.html"
@@ -27,7 +23,7 @@
       </a>
     </div>
   </div>
-  
+
   <div class="wrapper">
     <div class="u-floatLeft">
       <span class="all-caps">CHALLENGE</span>
@@ -39,9 +35,11 @@
     </div>
   </div>
 </header>
-      <div class="wrapper">
 
-              <div class="challenge">
+
+    <div class="wrapper" id="challenge-body">
+
+          <div class="challenge">
         <h2>The Challenge:</h2>
         <p>Submit a Pull Request on the original Patchwork repository.</p>
       </div>
@@ -104,7 +102,7 @@
       </div>
 
 
-        <div class="prenext">
+    <div class="prenext">
   <div class="u-floatLeft">
     <a href="pull_never_out_of_date.html" class="u-inline-block all-caps">pull never out of date
     <div>⤶ </div>
@@ -128,16 +126,18 @@
   </ul>
 </footer>
 
-      </div>
-      <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-        (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-        m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
-        ga('create', 'UA-52690821-1', 'auto');
-        ga('send', 'pageview');
+    </div>
 
-      </script>
-    </body>
+    <script>
+      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+      ga('create', 'UA-52690821-1', 'auto');
+      ga('send', 'pageview');
+    </script>
+
+  </body>
 </html>

--- a/data.json
+++ b/data.json
@@ -1,0 +1,6 @@
+{
+  "get_git": {
+    "completed": true,
+    "current_challenge": true
+  }
+}

--- a/layout.hbs
+++ b/layout.hbs
@@ -1,36 +1,37 @@
 <!doctype html>
-<html class="no-js" lang="">
-    <head>
-        <meta charset="utf-8">
-        <meta http-equiv="X-UA-Compatible" content="IE=edge">
-        <title>Git-it Guide</title>
-        <meta name="description" content="learn git and github">
-        <meta name="viewport" content="width=device-width, initial-scale=1">
-        <link rel="icon" href="../assets/imgs/favicon.png" type="image/x-icon">
-        <link rel="stylesheet" href="../assets/css/style.css">
-        <link href='http://fonts.googleapis.com/css?family=Source+Sans+Pro:400,600,700,900' rel='stylesheet' type='text/css'>
-    </head>
-    <body>
-      <!--[if lt IE 8]>
-          <p class="browsehappy">You are using an <strong>outdated</strong> browser. Please <a href="http://browsehappy.com/">upgrade your browser</a> to improve your experience.</p>
-      <![endif]-->
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible">
+    <title>Git-it</title>
+    <meta name="description" content="learn git and github">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="icon" href="../assets/imgs/favicon.png" type="image/x-icon">
+    <link rel="stylesheet" href="../assets/css/style.css">
+    <link href='http://fonts.googleapis.com/css?family=Source+Sans+Pro:400,600,700,900' rel='stylesheet' type='text/css'>
+  </head>
+  <body>
+    {{{header}}}
 
-        {{{header}}}
-      <div class="wrapper">
+    <div class="wrapper" id="challenge-body">
 
-        {{{body}}}
+    {{{body}}}
 
-        {{{footer}}}
-      </div>
-      <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-        (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-        m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+    </div>
 
-        ga('create', 'UA-52690821-1', 'auto');
-        ga('send', 'pageview');
+    <div class="wrapper">
+      {{{footer}}}
+    </div>
 
-      </script>
-    </body>
+    <script>
+      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+      ga('create', 'UA-52690821-1', 'auto');
+      ga('send', 'pageview');
+    </script>
+
+  </body>
 </html>

--- a/partials/header.html
+++ b/partials/header.html
@@ -10,7 +10,7 @@
       </a>
     </div>
   </div>
-  
+
   <div class="wrapper">
     <div class="u-floatLeft">
       <span class="all-caps">CHALLENGE</span>

--- a/raw-content/1_get_git.html
+++ b/raw-content/1_get_git.html
@@ -1,64 +1,77 @@
-            <div class="challenge">
-        <h2>The Challenge:</h2>
-        <p>Install Git on your computer and configure your name and email.</p>
-      </div>
+<div id="challenge-desc" class="challenge">
+  <h2>The Challenge:</h2>
+  <p>Install Git on your computer and configure your name and email.</p>
+</div>
 
-      <h2>Git</h2>
+<h2>Git</h2>
 
-      <p>Git is <strong>open source software</strong> (free for anyone to use) written
-        by Linus Torvalds who also wrote the Linux operating system. </p>
-      <p>It is a program for keeping track of changes over time, known in
-        programming as <strong>version control</strong>.</p>
+<p>Git is <strong>open source software</strong> (free for anyone to use) written
+  by Linus Torvalds who also wrote the Linux operating system. </p>
+<p>It is a program for keeping track of changes over time, known in
+  programming as <strong>version control</strong>.</p>
 
-      <h2>Step: Install Git</h2>
+<h2>Step: Install Git</h2>
 
-      <ul>
-        <li><strong>Windows</strong>: It's recommended to download GitHub for Windows,
-        which includes Git and has an easier install:
-        <a href="http://windows.github.com" target="_blank">windows.github.com</a>. Use the <strong>Git Shell</strong> for your terminal.</li>
+<ul>
+  <li><strong>Windows</strong>: It's recommended to download GitHub for Windows,
+  which includes Git and has an easier install:
+  <a href="http://windows.github.com" target="_blank">windows.github.com</a>. Use the <strong>Git Shell</strong> for your terminal.</li>
 
-        <li><strong>Mac</strong>: You can also download GitHub for Mac, which includes
-        Git, <a href="http://mac.github.com/" target="_blank">mac.github.com</a> (from Preferences, select
-        the command line tools install), or
-          <ul>
-            <li>download Git by itself at:
-            <a href="http://git-scm.com/downloads" target="_blank">git-scm.com/downloads</a> and follow the installation instructions.</li>
-          </ul>
-        </li>
-      </ul>
+  <li><strong>Mac</strong>: You can also download GitHub for Mac, which includes
+  Git, <a href="http://mac.github.com/" target="_blank">mac.github.com</a> (from Preferences, select
+  the command line tools install), or
+    <ul>
+      <li>download Git by itself at:
+      <a href="http://git-scm.com/downloads" target="_blank">git-scm.com/downloads</a> and follow the installation instructions.</li>
+    </ul>
+  </li>
+</ul>
 
-      <p>Git isn't like other programs on your computer. You'll likely not
-      see an icon on your desktop, but it will always be available to you
-      and you'll be able to access it at anytime from your
-      terminal (which you're using in Git-it!) or Git desktop applications (like GitHub for Mac or Windows).</p>
+<p>Git isn't like other programs on your computer. You'll likely not
+see an icon on your desktop, but it will always be available to you
+and you'll be able to access it at anytime from your
+terminal (which you're using in Git-it!) or Git desktop applications (like GitHub for Mac or Windows).</p>
 
-      <h2>Step: Configure Git</h2>
-      <p>Once it is installed, open <strong>terminal</strong> (aka Bash, aka Shell, aka Prompt).
-      You can verify that it's really there by typing:</p>
+<h2>Step: Configure Git</h2>
+<p>Once it is installed, open <strong>terminal</strong> (aka Bash, aka Shell, aka Prompt).
+You can verify that it's really there by typing:</p>
 
-      <p><code>$ git --version </code></p>
+<p><code>$ git --version </code></p>
 
-      <p>This will return the version of Git that you're running and look something like this:</p>
+<p>This will return the version of Git that you're running and look something like this:</p>
 
-      <p><code>git version 1.9.1</code></p>
+<p><code>git version 1.9.1</code></p>
 
-      <p>(Any version <code>1.7.10</code> or higher is fine.)</p>
+<p>(Any version <code>1.7.10</code> or higher is fine.)</p>
 
-      <p>Next, configure Git so it knows who to associate your changes to:</p>
+<p>Next, configure Git so it knows who to associate your changes to:</p>
 
-      <p>Set your name:</p>
-      <p><code>$ git config --global user.name "&#60;Your Name&#62;"</code></p>
-      <p>Now set your email:</p>
-      <p><code>$ git config --global user.email "&#60;youremail@example.com&#62;"</code></p>
+<p>Set your name:</p>
+<p><code>$ git config --global user.name "&#60;Your Name&#62;"</code></p>
+<p>Now set your email:</p>
+<p><code>$ git config --global user.email "&#60;youremail@example.com&#62;"</code></p>
 
-      <div class="verify">
-        <h3>Verify with </h3> <code>git-it verify </code><br>
-        <h3>Go to the next challenge </h3> <code>git-it</code>
-      </div>
+<div class="verify">
+  <button id='verify-challenge'>VERIFY</button>
+  <ul id="verify-list">
+  </ul>
+</div>
 
-      <div id="git-tips">
-        <h2>Tips</h2>
-        <p>Dollar signs <code>$</code> are often used in programming documentation
-      to signify that the line is <strong>command line</strong> code (see the code snippets above). You don't actually
-      type the <code>$</code> in though, only type what comes after. For instance, to run the verify command above, you're actually going to type <code>git-it verify</code> into terminal.</p>
-      </div>
+<div id="git-tips">
+  <h2>Tips</h2>
+  <p>Dollar signs <code>$</code> are often used in programming documentation
+to signify that the line is <strong>command line</strong> code (see the code snippets above). You don't actually
+type the <code>$</code> in though, only type what comes after. For instance, to run the verify command above, you're actually going to type <code>git-it verify</code> into terminal.</p>
+</div>
+
+<script>
+  var verifyChallenge = require('../verify/get_git.js')
+
+  var verifyButton = document.getElementById('verify-challenge')
+  var ul = document.getElementById('verify-list')
+
+  verifyButton.addEventListener('click', function clicked (event) {
+    ul.innerHTML = ''
+    verifyChallenge()
+  })
+</script>

--- a/verify/get_git.js
+++ b/verify/get_git.js
@@ -1,0 +1,55 @@
+var exec = require('child_process').exec
+
+var helper = require('../verify/helpers.js')
+var userData = require('../data.json')
+
+var addToList = helper.addtoList
+var markChallengeCompleted = helper.markChallengeCompleted
+var writeData = helper.writeData
+
+var currentChallenge = 'get_git'
+
+var total = 3
+var counter = 0
+
+// TODO
+// Think about how best to show errors to user
+// All that nesting
+// Potentially put all responses in array, use length for total
+
+module.exports = function verifyGetGitChallenge () {
+  exec('git config user.email', function (err, stdout, stderr) {
+    if (err) return addToList('An error verifying! Try again.', false)
+    var email = stdout.trim()
+    if (email === '') {
+      addToList('No email found.', false)
+    } else {
+      counter++
+      addToList('Email Added', true)
+      exec('git config user.name', function (err, stdout, stderr) {
+        if (err) return addToList('An error verifying! Try again.', false)
+        var name = stdout.trim()
+        if (name === '') {
+          addToList('No name found.', false)
+        } else {
+          counter++
+          addToList('Name Added!', true)
+          exec('git --version', function (err, stdout, stdrr) {
+            if (err) return addToList('An error verifying! Try again.', false)
+            var gitOutput = stdout.trim()
+            if (gitOutput.match('git version')) {
+              counter++
+              addToList('Found Git installed.', true)
+            } else {
+              addToList('Found no Git installed.', false)
+            }
+            if (counter === total) {
+              markChallengeCompleted()
+              writeData(userData, currentChallenge)
+            }
+          })
+        }
+      })
+    }
+  })
+}

--- a/verify/helpers.js
+++ b/verify/helpers.js
@@ -1,0 +1,34 @@
+var fs = require('fs')
+
+var ul = document.getElementById('verify-list')
+
+var addtoList = function (message, status) {
+  var li = document.createElement('li')
+  var newContent = document.createTextNode(message)
+  li.appendChild(newContent)
+  if (status) {
+    li.classList.add('verify-pass')
+  } else li.classList.add('verify-fail')
+  ul.appendChild(li)
+  // potentially do this with domify and push
+  // into an array and add to dom once
+}
+
+var markChallengeCompleted = function () {
+  var challengeBody = document.getElementById('challenge-body')
+  var challengeDesc = document.getElementById('challenge-desc')
+  var div = document.createElement('h2')
+  var newContent = document.createTextNode('COMPLETED!')
+  div.appendChild(newContent)
+  div.classList.add('completed-challenge')
+  challengeBody.insertBefore(div, challengeDesc)
+}
+
+var writeData = function (userData, challenge) {
+  userData.get_git.completed = true
+  fs.writeFileSync('./data.json', JSON.stringify(userData, null, 2))
+}
+
+module.exports.writeData = writeData
+module.exports.markChallengeCompleted = markChallengeCompleted
+module.exports.addtoList = addtoList


### PR DESCRIPTION
This pull request will contain a lot of small things, like clean up, but the important part is that I'm working out how verifying challenges will happen in this new version of the app, since it will no longer take place in Terminal. 

I started with one challenge, the first, Get Git, and tested a few ideas and went with one that seemed the best option. It's rough and the design has not yet been polished, and that's already, right now it's about getting things wired up and working. 

So, the plan is is to add a 'verify' button at the bottom of each challenge. When the user is ready to verify this challenge, they click and it runs verify. Some challenges involve multiple parts and if each passes the challenge will be set as completed. 

![screen shot 2015-05-13 at 10 06 02 pm](https://cloud.githubusercontent.com/assets/1305617/7626730/5886595c-f9c2-11e4-819e-b12b184b268d.png)

![screen shot 2015-05-13 at 10 06 07 pm](https://cloud.githubusercontent.com/assets/1305617/7626731/5c475348-f9c2-11e4-8d03-6fcf28622377.png)

A file is created to store completed statuses for the challenges. 

**Still to consider**
- [ ] For some challenges the user will need to select the directory that their Git repository to be verified is in.
- [ ] When the pages load they should load the completed/uncompleted state of each challenge.
- [ ] Add a clear-completed-statuses option
- [ ] Write tests
