### PR TITLE
Open External Links in Default Browser

### DIFF
--- a/challenges/branches_arent_just_for_birds.html
+++ b/challenges/branches_arent_just_for_birds.html
@@ -9,6 +9,7 @@
     <link rel="icon" href="../assets/imgs/favicon.png" type="image/x-icon">
     <link rel="stylesheet" href="../assets/css/style.css">
     <link href='http://fonts.googleapis.com/css?family=Source+Sans+Pro:400,600,700,900' rel='stylesheet' type='text/css'>
+    <script>require('../handle-external-links.js')</script>
   </head>
   <body>
     <header class="site-header">

--- a/challenges/commit_to_it.html
+++ b/challenges/commit_to_it.html
@@ -9,6 +9,7 @@
     <link rel="icon" href="../assets/imgs/favicon.png" type="image/x-icon">
     <link rel="stylesheet" href="../assets/css/style.css">
     <link href='http://fonts.googleapis.com/css?family=Source+Sans+Pro:400,600,700,900' rel='stylesheet' type='text/css'>
+    <script>require('../handle-external-links.js')</script>
   </head>
   <body>
     <header class="site-header">

--- a/challenges/forks_and_clones.html
+++ b/challenges/forks_and_clones.html
@@ -9,6 +9,7 @@
     <link rel="icon" href="../assets/imgs/favicon.png" type="image/x-icon">
     <link rel="stylesheet" href="../assets/css/style.css">
     <link href='http://fonts.googleapis.com/css?family=Source+Sans+Pro:400,600,700,900' rel='stylesheet' type='text/css'>
+    <script>require('../handle-external-links.js')</script>
   </head>
   <body>
     <header class="site-header">

--- a/challenges/get_git.html
+++ b/challenges/get_git.html
@@ -9,6 +9,7 @@
     <link rel="icon" href="../assets/imgs/favicon.png" type="image/x-icon">
     <link rel="stylesheet" href="../assets/css/style.css">
     <link href='http://fonts.googleapis.com/css?family=Source+Sans+Pro:400,600,700,900' rel='stylesheet' type='text/css'>
+    <script>require('../handle-external-links.js')</script>
   </head>
   <body>
     <header class="site-header">

--- a/challenges/githubbin.html
+++ b/challenges/githubbin.html
@@ -9,6 +9,7 @@
     <link rel="icon" href="../assets/imgs/favicon.png" type="image/x-icon">
     <link rel="stylesheet" href="../assets/css/style.css">
     <link href='http://fonts.googleapis.com/css?family=Source+Sans+Pro:400,600,700,900' rel='stylesheet' type='text/css'>
+    <script>require('../handle-external-links.js')</script>
   </head>
   <body>
     <header class="site-header">

--- a/challenges/its_a_small_world.html
+++ b/challenges/its_a_small_world.html
@@ -9,6 +9,7 @@
     <link rel="icon" href="../assets/imgs/favicon.png" type="image/x-icon">
     <link rel="stylesheet" href="../assets/css/style.css">
     <link href='http://fonts.googleapis.com/css?family=Source+Sans+Pro:400,600,700,900' rel='stylesheet' type='text/css'>
+    <script>require('../handle-external-links.js')</script>
   </head>
   <body>
     <header class="site-header">

--- a/challenges/merge_tada.html
+++ b/challenges/merge_tada.html
@@ -9,6 +9,7 @@
     <link rel="icon" href="../assets/imgs/favicon.png" type="image/x-icon">
     <link rel="stylesheet" href="../assets/css/style.css">
     <link href='http://fonts.googleapis.com/css?family=Source+Sans+Pro:400,600,700,900' rel='stylesheet' type='text/css'>
+    <script>require('../handle-external-links.js')</script>
   </head>
   <body>
     <header class="site-header">

--- a/challenges/pull_never_out_of_date.html
+++ b/challenges/pull_never_out_of_date.html
@@ -9,6 +9,7 @@
     <link rel="icon" href="../assets/imgs/favicon.png" type="image/x-icon">
     <link rel="stylesheet" href="../assets/css/style.css">
     <link href='http://fonts.googleapis.com/css?family=Source+Sans+Pro:400,600,700,900' rel='stylesheet' type='text/css'>
+    <script>require('../handle-external-links.js')</script>
   </head>
   <body>
     <header class="site-header">

--- a/challenges/remote_control.html
+++ b/challenges/remote_control.html
@@ -9,6 +9,7 @@
     <link rel="icon" href="../assets/imgs/favicon.png" type="image/x-icon">
     <link rel="stylesheet" href="../assets/css/style.css">
     <link href='http://fonts.googleapis.com/css?family=Source+Sans+Pro:400,600,700,900' rel='stylesheet' type='text/css'>
+    <script>require('../handle-external-links.js')</script>
   </head>
   <body>
     <header class="site-header">

--- a/challenges/repository.html
+++ b/challenges/repository.html
@@ -9,6 +9,7 @@
     <link rel="icon" href="../assets/imgs/favicon.png" type="image/x-icon">
     <link rel="stylesheet" href="../assets/css/style.css">
     <link href='http://fonts.googleapis.com/css?family=Source+Sans+Pro:400,600,700,900' rel='stylesheet' type='text/css'>
+    <script>require('../handle-external-links.js')</script>
   </head>
   <body>
     <header class="site-header">

--- a/challenges/requesting_you_pull_please.html
+++ b/challenges/requesting_you_pull_please.html
@@ -9,6 +9,7 @@
     <link rel="icon" href="../assets/imgs/favicon.png" type="image/x-icon">
     <link rel="stylesheet" href="../assets/css/style.css">
     <link href='http://fonts.googleapis.com/css?family=Source+Sans+Pro:400,600,700,900' rel='stylesheet' type='text/css'>
+    <script>require('../handle-external-links.js')</script>
   </head>
   <body>
     <header class="site-header">

--- a/handle-external-links.js
+++ b/handle-external-links.js
@@ -1,0 +1,19 @@
+var shell = require('shell')
+
+document.addEventListener('DOMContentLoaded', function (event) {
+  var links = document.querySelectorAll('a[href]')
+
+  for (var l in links) {
+    var url = ''
+    if (typeof links[l] === 'object') {
+      url = links[l].getAttribute('href')
+    }
+    if (url.indexOf('http:') > -1) {
+      var gohere = url // not sure why this had to be here
+      links[l].addEventListener('click', function (e) {
+        e.preventDefault()
+        shell.openExternal(gohere)
+      })
+    }
+  }
+})

--- a/layout.hbs
+++ b/layout.hbs
@@ -9,6 +9,7 @@
     <link rel="icon" href="../assets/imgs/favicon.png" type="image/x-icon">
     <link rel="stylesheet" href="../assets/css/style.css">
     <link href='http://fonts.googleapis.com/css?family=Source+Sans+Pro:400,600,700,900' rel='stylesheet' type='text/css'>
+    <script>require('../handle-external-links.js')</script>
   </head>
   <body>
     {{{header}}}


### PR DESCRIPTION
Since Electron apps are showing webpages that you make they can also show other webpages that you link to in your app. If they're not actually a part of your app, you may prefer them to open up in the user's default browser. 

That's what we're gonna do. In various places I link out to other GitHub or Git resources. Those will now open outside of the Git-it app and in the user's browser. 

To do this we use the `shell` module and the method it has, `openExternal`, which takes in a url. You can read more about it on the [documentation page for `shell` in Electron](http://electron.atom.io/docs/v0.27.0/api/shell/).

So in the template for each page, `layout.hbs` (and in the `index.html`) we require the script that we'll use to handle these external links:

```js
<script>require('../handle-external-links.js')</script>
```

Then in that script we wait until the page is loaded and loop through each of its links. We see if the link includes a `http`, meaning it's an external link, not a relative link (e.g. `../.../file.html`) to another Git-it file.

With each external link we find we add a click event that uses `shell` to open the link in the browser.

```js
shell.openExternal('http://github.com/jlord/git-it-electron')
``` 

Here's the [rest of that code](https://github.com/jlord/git-it-electron/compare/master...external-links#diff-1d7e628389fe643aed300b0079bae803).

Fixes https://github.com/jlord/git-it-electron/issues/7