### PR TITLE
Improve/fix Opening External Links

### DIFF
--- a/handle-external-links.js
+++ b/handle-external-links.js
@@ -3,16 +3,12 @@ var shell = require('shell')
 document.addEventListener('DOMContentLoaded', function (event) {
   var links = document.querySelectorAll('a[href]')
 
-  for (var l in links) {
-    var url = ''
-    if (typeof links[l] === 'object') {
-      url = links[l].getAttribute('href')
-    }
+  [].forEach.call(links, function (link) {
+    var url = link.getAttribute('href')
     if (url.indexOf('http:') > -1) {
-      var gohere = url // not sure why this had to be here
-      links[l].addEventListener('click', function (e) {
+      link.addEventListener('click', function (e) {
         e.preventDefault()
-        shell.openExternal(gohere)
+        shell.openExternal(url)
       })
     }
   }


### PR DESCRIPTION
I hadn't had to do this before and it made my mind hurt a little but there's _one weird trick_ for looping through a [DOM Nodelist](https://developer.mozilla.org/en-US/docs/Web/API/NodeList) (what you get back when you query the document for a type of element). Here's what I learned! :books: 

You create an empty array, use its for each method on the list, `links`. Nodelist is _similar_ to an array, but doesn't have the properties of an array. And in this instance where we're setting a click event on each element, the `forEach` that array's have will work. Because the `forEach` creates a function, your `url` var stays in scope (this also makes `forEach` slower than `for` but not enough that we'd notice in this app) — it's likely my original script wasn't truly working (it was probably returning the last link set to url each time). 

So, it looks weird, but it gets the job done here. 