### PR TITLE
Add IPC to/from events for confirm dialogue

### DIFF
--- a/challenges-completed.js
+++ b/challenges-completed.js
@@ -10,9 +10,18 @@ document.addEventListener('DOMContentLoaded', function (event) {
     updateIndex('./data.json')
   })
 
+  ipc.on('confirm-clear-response', function (response) {
+    if (response === 1) return
+    else clearAllChallenges()
+  })
+
   var clearAllButton = document.getElementById('clear-all-challenges')
 
   clearAllButton.addEventListener('click', function (event) {
+    ipc.send('confirm-clear')
+  })
+
+  function clearAllChallenges () {
     for (var chal in userData) {
       if (userData[chal].completed) {
         userData[chal].completed = false
@@ -23,7 +32,7 @@ document.addEventListener('DOMContentLoaded', function (event) {
     fs.writeFile('./data.json', JSON.stringify(userData, null, ' '), function (err) {
       if (err) return console.log(err)
     })
-  })
+  }
 
   function updateIndex (path) {
     fs.readFile(path, function readFile (err, contents) {

--- a/main.js
+++ b/main.js
@@ -35,6 +35,18 @@ app.on('ready', function appReady () {
     }
   })
 
+  ipc.on('confirm-clear', function (event) {
+    var options = {
+      type: 'info',
+      buttons: ['Yes', 'No'],
+      title: 'Confirm Clearing Statuses',
+      message: 'Are you sure you want to clear the status for every challenge?'
+    }
+    dialog.showMessageBox(options, function cb (response) {
+      event.sender.send('confirm-clear-response', response)
+    })
+  })
+
   if (process.platform === 'darwin') {
     menu = Menu.buildFromTemplate(darwinTemplate(app, mainWindow))
     Menu.setApplicationMenu(menu)


### PR DESCRIPTION
This one is fun! Before users actually clear all their completed statuses for challenges, I want to confirm that they actually want to _clear them all_. So I use `ipc`, the module that lets the web pages talk to the main process, to send a system dialog box to the user asking them to confirm. If they say yes, then I actually clear the data. 

When the 'Clear all challenge statuses' button is clicked, we send an event, with `ipc`, to the main process named 'confirm clear'.
![screen shot 2015-06-19 at 3 18 51 pm](https://cloud.githubusercontent.com/assets/1305617/8264054/835bbae6-1696-11e5-9a61-0745bec821da.png)

```js
  var clearAllButton = document.getElementById('clear-all-challenges')

  clearAllButton.addEventListener('click', function (event) {
    ipc.send('confirm-clear')
  })
```

Then in `main.js` we define the 'confirm-clear' event. We say that on this event we're going to open a dialog box and ask the user a question.

![screen shot 2015-06-19 at 3 24 38 pm](https://cloud.githubusercontent.com/assets/1305617/8264122/553007a2-1697-11e5-8336-a1befbe7ad13.png)

```js
  ipc.on('confirm-clear', function (event) {
    var options = {
      type: 'info',
      buttons: ['Yes', 'No'],
      title: 'Confirm Clearing Statuses',
      message: 'Are you sure you want to clear the status for every challenge?'
    }
    dialog.showMessageBox(options, function cb (response) {
      event.sender.send('confirm-clear-response', response)
    })
  })
```

Then when the user responds we'll send another event, 'confirm-clear-response'. We're listening for this event back in our other file, where we sent the first event. We say, when we hear the 'confirm-clear-response' event we want to do something with the response it contains. If the response is `0` it means they picked 'Yes', the first option we defined in our buttons array for the dialog, and we want to continue by running the function to clear the statuses. If it is `1` then they said no and we don't need to do anything, just return out of the function.

```js
  ipc.on('confirm-clear-response', function (response) {
    if (response === 1) return
    else clearAllChallenges()
  })
```

:tada: 