### PR TITLE
GitHub for (Mac,Windows) -> GitHub Desktop

### DIFF
--- a/challenge-content-zhtw/1_get_git.html
+++ b/challenge-content-zhtw/1_get_git.html
@@ -11,11 +11,11 @@
       <h2>步驟：安裝 Git</h2>
 
       <ul>
-        <li><strong>Windows 系統</strong>：建議你下載 GitHub for Windows 這個軟體。這個程式內包含 Git 在裡頭，而且比較容易安裝：
-        <a href="https://windows.github.com/" target="_blank">windows.github.com</a>。你可以用 <strong>Git Shell</strong> 作為你的終端機。</li>
+        <li><strong>Windows 系統</strong>：建議你下載 GitHub Desktop 這個軟體。這個程式內包含 Git 在裡頭，而且比較容易安裝：
+        <a href="https://desktop.github.com/" target="_blank">desktop.github.com</a>。你可以用 <strong>Git Shell</strong> 作為你的終端機。</li>
 
-        <li><strong>Mac 系統</strong>: 你可以下載 GitHub for Mac 這個軟體，裡頭也包含 Git 的程式。
-        <a href="https://mac.github.com/" target="_blank">mac.github.com</a>（必須到「Preferences」中選擇「Install Command Line Tools」）。或是：
+        <li><strong>Mac 系統</strong>: 你可以下載 GitHub Desktop 這個軟體，裡頭也包含 Git 的程式。
+        <a href="https://desktop.github.com/" target="_blank">desktop.github.com</a>（必須到「Preferences」中選擇「Install Command Line Tools」）。或是：
           <ul>
             <li>直接下載、安裝 Git 主程式：前往 <a href="http://git-scm.com/downloads" target="_blank">git-scm.com/downloads</a> 並按照網頁上的步驟安裝。</li>
           </ul>

--- a/challenge-content-zhtw/1_get_git.html
+++ b/challenge-content-zhtw/1_get_git.html
@@ -23,7 +23,7 @@
       </ul>
 
       <p>Git 不像是你電腦裡的其他軟體。你不會在桌面上看到一個軟體圖示，但你可以透過終端機或是其他 Git
-        的電腦程式（如 GitHub for Mac 或 GitHub for Windows）來使用。而終端機就是我們在 Git-it 中將會使用的程式！</p>
+        的電腦程式（如 GitHub Desktop）來使用。而終端機就是我們在 Git-it 中將會使用的程式！</p>
 
       <h2>步驟：設定 Git</h2>
 

--- a/challenge-content/1_get_git.html
+++ b/challenge-content/1_get_git.html
@@ -30,7 +30,7 @@
 <p>Git isn't like other programs on your computer. You'll likely not
 see an icon on your desktop, but it will always be available to you
 and you'll be able to access it at anytime from your
-terminal (which you're using in Git-it!) or Git desktop applications (like GitHub for Mac or Windows).</p>
+terminal (which you're using in Git-it!) or Git desktop applications (like GitHub Desktop).</p>
 
 <h2>Step: Configure Git</h2>
 <p>Once it is installed, open <strong>terminal</strong> (aka Bash, aka Shell, aka Prompt).

--- a/challenge-content/1_get_git.html
+++ b/challenge-content/1_get_git.html
@@ -13,12 +13,12 @@
 <h2>Step: Install Git</h2>
 
 <ul>
-  <li><strong>Windows</strong>: It's recommended to download GitHub for Windows,
+  <li><strong>Windows</strong>: It's recommended to download GitHub Desktop,
   which includes Git and has an easier install:
-  <a href="http://windows.github.com" target="_blank">windows.github.com</a>. Use the <strong>Git Shell</strong> for your terminal.</li>
+  <a href="http://desktop.github.com" target="_blank">desktop.github.com</a>. Use the <strong>Git Shell</strong> for your terminal.</li>
 
-  <li><strong>Mac</strong>: You can also download GitHub for Mac, which includes
-  Git, <a href="http://mac.github.com/" target="_blank">mac.github.com</a> (from Preferences, select
+  <li><strong>Mac</strong>: You can also download GitHub Desktop, which includes
+  Git, <a href="http://desktop.github.com/" target="_blank">desktop.github.com</a> (from Preferences, select
   the command line tools install), or
     <ul>
       <li>download Git by itself at:


### PR DESCRIPTION
We shipped GitHub Desktop a few weeks ago, so I'm renaming some of the references to the old products in the first step.

The steps remain the same for accessing the CLI for both tools.

I think I have updated the translation correctly, let me know if I messed it up.