### PR TITLE
Provide the browser window object

### DIFF
--- a/main.js
+++ b/main.js
@@ -44,7 +44,7 @@ app.on('ready', function appReady () {
   })
 
   ipc.on('open-file-dialog', function (event) {
-    var files = dialog.showOpenDialog({ properties: [ 'openFile', 'openDirectory' ]})
+    var files = dialog.showOpenDialog(mainWindow, { properties: [ 'openFile', 'openDirectory' ]})
     if (files) {
       event.sender.send('selected-directory', files)
     }


### PR DESCRIPTION
If we do not pass the browser window object to the showOpenDialog method, the second time when the dialog is opened, on Linux, it is opened under the current window. This change fixes this behavior.

Fixes #60. :dizzy: 