### PR TITLE
Fix license to the SPDX License format

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "url": "https://github.com/jlord/git-it-electron.git"
   },
   "author": "Jessica Lord",
-  "license": "BSD",
+  "license": "BSD-2-Clause",
   "bugs": {
     "url": "https://github.com/jlord/git-it-electron/issues"
   },


### PR DESCRIPTION
Removes the following warning:

<img width="718" alt="screen shot 2015-10-30 at 2 32 07 pm" src="https://cloud.githubusercontent.com/assets/432489/10856052/0b507894-7f13-11e5-900f-060edd398a23.png">

I think this is the exact license you are using: http://spdx.org/licenses/BSD-2-Clause.html