### PR TITLE
make readme screenshot link to releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.org/maxogden/electron-packager.svg?branch=master)](https://travis-ci.org/maxogden/electron-packager)
 
-![img](https://cloud.githubusercontent.com/assets/1305617/9652620/fce0cc46-51d1-11e5-9cb6-d2d71535dfc5.png)
+[![screenshot](https://cloud.githubusercontent.com/assets/1305617/9652620/fce0cc46-51d1-11e5-9cb6-d2d71535dfc5.png)](https://github.com/jlord/git-it-electron/releases)
 
 Git-it is an app that teaches you Git and GitHub on the [command line](https://en.wikipedia.org/wiki/Command-line_interface).
 


### PR DESCRIPTION
github.com automatically wraps the screenshot at the top of the readme in a link to the screenshot image itself. This PR makes it link to https://github.com/jlord/git-it-electron/releases instead.