### PR TITLE
Improve shell prompts

### DIFF
--- a/assets/PortableGit/mingw32/share/doc/git-doc/git-subtree.html
+++ b/assets/PortableGit/mingw32/share/doc/git-doc/git-subtree.html
@@ -1074,7 +1074,7 @@ git-subtree repository as a subdirectory of your already existing
 git-extensions repository in ~/git-extensions/:</p></div>
 <div class="literalblock">
 <div class="content">
-<pre><code>$ git subtree add --prefix=git-subtree --squash \
+<pre><code class="shell">git subtree add --prefix=git-subtree --squash \
         git://github.com/apenwarr/git-subtree.git master</code></pre>
 </div></div>
 <div class="paragraph"><p><em>master</em> needs to be a valid remote ref and can be a different branch
@@ -1093,7 +1093,7 @@ in our git-extensions repository.</p></div>
 First, get your own copy of the git.git repository:</p></div>
 <div class="literalblock">
 <div class="content">
-<pre><code>$ git clone git://git.kernel.org/pub/scm/git/git.git test-git
+<pre><code class="shell">git clone git://git.kernel.org/pub/scm/git/git.git test-git
 $ cd test-git</code></pre>
 </div></div>
 <div class="paragraph"><p>gitweb (commit 1130ef3) was merged into git as of commit
@@ -1103,7 +1103,7 @@ extract git&#8217;s changes to gitweb since that time, to share with
 the upstream.  You could do this:</p></div>
 <div class="literalblock">
 <div class="content">
-<pre><code>$ git subtree split --prefix=gitweb --annotate='(split) ' \
+<pre><code class="shell">git subtree split --prefix=gitweb --annotate='(split) ' \
         0a8f4f0^.. --onto=1130ef3 --rejoin \
         --branch gitweb-latest
 $ gitk gitweb-latest
@@ -1117,38 +1117,38 @@ then you can do all your splits without having to remember any
 weird commit ids:</p></div>
 <div class="literalblock">
 <div class="content">
-<pre><code>$ git subtree split --prefix=gitweb --annotate='(split) ' --rejoin \
+<pre><code class="shell">git subtree split --prefix=gitweb --annotate='(split) ' --rejoin \
         --branch gitweb-latest2</code></pre>
 </div></div>
 <div class="paragraph"><p>And you can merge changes back in from the upstream project just
 as easily:</p></div>
 <div class="literalblock">
 <div class="content">
-<pre><code>$ git subtree pull --prefix=gitweb \
+<pre><code class="shell">git subtree pull --prefix=gitweb \
         git@github.com:whatever/gitweb.git master</code></pre>
 </div></div>
 <div class="paragraph"><p>Or, using <em>--squash</em>, you can actually rewind to an earlier
 version of gitweb:</p></div>
 <div class="literalblock">
 <div class="content">
-<pre><code>$ git subtree merge --prefix=gitweb --squash gitweb-latest~10</code></pre>
+<pre><code class="shell">git subtree merge --prefix=gitweb --squash gitweb-latest~10</code></pre>
 </div></div>
 <div class="paragraph"><p>Then make some changes:</p></div>
 <div class="literalblock">
 <div class="content">
-<pre><code>$ date &gt;gitweb/myfile
+<pre><code class="shell">date &gt;gitweb/myfile
 $ git add gitweb/myfile
 $ git commit -m 'created myfile'</code></pre>
 </div></div>
 <div class="paragraph"><p>And fast forward again:</p></div>
 <div class="literalblock">
 <div class="content">
-<pre><code>$ git subtree merge --prefix=gitweb --squash gitweb-latest</code></pre>
+<pre><code class="shell">git subtree merge --prefix=gitweb --squash gitweb-latest</code></pre>
 </div></div>
 <div class="paragraph"><p>And notice that your change is still intact:</p></div>
 <div class="literalblock">
 <div class="content">
-<pre><code>$ ls -l gitweb/myfile</code></pre>
+<pre><code class="shell">ls -l gitweb/myfile</code></pre>
 </div></div>
 <div class="paragraph"><p>And you can split it out and look at your changes versus
 the standard gitweb:</p></div>
@@ -1167,18 +1167,18 @@ git project. Here&#8217;s a short way to do it:</p></div>
 <div class="paragraph"><p>First, make the new repository wherever you want:</p></div>
 <div class="literalblock">
 <div class="content">
-<pre><code>$ &lt;go to the new location&gt;
+<pre><code class="shell">&lt;go to the new location&gt;
 $ git init --bare</code></pre>
 </div></div>
 <div class="paragraph"><p>Back in your original directory:</p></div>
 <div class="literalblock">
 <div class="content">
-<pre><code>$ git subtree split --prefix=lib --annotate="(split)" -b split</code></pre>
+<pre><code class="shell">git subtree split --prefix=lib --annotate="(split)" -b split</code></pre>
 </div></div>
 <div class="paragraph"><p>Then push the new branch onto the new empty repository:</p></div>
 <div class="literalblock">
 <div class="content">
-<pre><code>$ git push &lt;new-repo&gt; split:master</code></pre>
+<pre><code class="shell">git push &lt;new-repo&gt; split:master</code></pre>
 </div></div>
 </div>
 </div>

--- a/assets/PortableGit/mingw32/share/doc/git-doc/giteveryday.html
+++ b/assets/PortableGit/mingw32/share/doc/git-doc/giteveryday.html
@@ -1015,7 +1015,7 @@ Others might be different.</p>
 <dt class="hdlist1">Give push/pull only access to developers using git-over-ssh.</dt>
 <dd>
 <p>e.g. those using:
-<code>$ git push/pull ssh://host.xz/pub/scm/project</code></p>
+<code class="shell">git push/pull ssh://host.xz/pub/scm/project</code></p>
 <div class="listingblock">
 <div class="content">
 <pre>$ grep git /etc/passwd <b class="conum">(1)</b>

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -317,6 +317,11 @@ code, .outof {
   white-space: nowrap;
 }
 
+code.shell:before {
+  content: "$ ";
+  opacity: 0.4;
+}
+
 footer {
   border-top: 3px solid #0087ff;
   margin: 20px 0 0;

--- a/challenge-content-zhtw/11_merge_tada.html
+++ b/challenge-content-zhtw/11_merge_tada.html
@@ -9,24 +9,24 @@
 
       <p>首先，切換到想要 <v>merge</v> <strong>進去</strong>的 <n>branch</n>，也就是 'gh-pages'。</p>
 
-      <p><code>$ git checkout gh-pages</code></p>
+      <p><code class="shell">git checkout gh-pages</code></p>
 
       <p>告訴 Git 你想要 <v>merge</v> 那個 <n>branch</n> <strong>進來</strong>，也就是你的 <n>feature</n> <n>branch</n>，名字是 'add-username'。</p>
 
-      <p><code>$ git merge &#60;BRANCHNAME&#62;</code></p>
+      <p><code class="shell">git merge &#60;BRANCHNAME&#62;</code></p>
 
       <p>整理一下吧，現在把剛剛已經 <v>merged</v> 的 <n>feature</n> <n>branch</n> 刪掉。</p>
-      <p><code>$ git branch -d &#60;BRANCHNAME&#62;</code></p>
+      <p><code class="shell">git branch -d &#60;BRANCHNAME&#62;</code></p>
 
       <p>也可以把 <n>branch</n> 從 GitHub 上的 <adj>forked</adj> <n>repository</n> 中刪除哦：</p>
-      <p><code>$ git push &#60;REMOTENAME&#62; --delete &#60;BRANCHNAME&#62;</code></p>
+      <p><code class="shell">git push &#60;REMOTENAME&#62; --delete &#60;BRANCHNAME&#62;</code></p>
 
       <h2>步驟： 從 <n>Upstream</n> <v>Pull</v></h2>
       <p>最後一步，但也是很重要的一步，若從原專案（現在首頁已經有你的名字了哦）<v>pull</v> 回來，你也會有一個相同的網頁，位置在 yourusername.github.io/patchwork。</p>
 
       <p>從原本的 <n>upstream</n> <v>pull</v> 回來：</p>
 
-      <p><code>$ git pull upstream gh-pages</code></p>
+      <p><code class="shell">git pull upstream gh-pages</code></p>
 
       <h2>恭喜恭喜！</h2>
       <p>你在本機建立了 <n>repositories</n>，與一名 <n>collaborator</n> 協作、<v>push</v>、<v>pull</v>，加入了百萬開發者所處的開源世界，是你，豐富了開源世界！</p>
@@ -38,14 +38,14 @@
         <h2>撇步</h2>
         <ul>
           <li><strong><v>Merge</v> <n>branch</n> 到目前的 <n>branch</n></strong></li>
-          <code>$ git merge &#60;BRANCHNAME&#62;</code>
+          <code class="shell">git merge &#60;BRANCHNAME&#62;</code>
           <li><strong>切換正在工作的 <n>branch</n></strong></li>
-          <code>$ git checkout &#60;BRANCHNAME&#62;</code>
+          <code class="shell">git checkout &#60;BRANCHNAME&#62;</code>
           <li><strong>刪除本機的 <n>branch</n></strong></li>
-          <code>$ git branch -d &#60;BRANCHNAME&#62;</code>
+          <code class="shell">git branch -d &#60;BRANCHNAME&#62;</code>
           <li><strong>刪除 <n>remote</n> <n>branch</n></strong></li>
-          <code>$ git push &#60;REMOTENAME&#62; --delete &#60;BRANCHNAME&#62;</code>
+          <code class="shell">git push &#60;REMOTENAME&#62; --delete &#60;BRANCHNAME&#62;</code>
           <li><strong>從 <n>remote</n> <n>branch</n> <v>Pull</v></strong></li>
-          <code>$ git pull &#60;REMOTENAME&#62; &#60;BRANCHNAME&#62;</code>
+          <code class="shell">git pull &#60;REMOTENAME&#62; &#60;BRANCHNAME&#62;</code>
         </ul>
       </div>

--- a/challenge-content-zhtw/1_get_git.html
+++ b/challenge-content-zhtw/1_get_git.html
@@ -29,7 +29,7 @@
 
       <p>安裝好 Git 後，打開 <strong>終端機</strong>（或 Bash、Shell、Prompt、命令提示字元介面），並輸入以下指令來確認你有順利安裝好 Git：</p>
 
-      <p><code>$ git --version </code></p>
+      <p><code class="shell">git --version </code></p>
 
       <p>如果有安裝成功，這個指令將會告訴你，你所安裝的版本號碼，如：</p>
 
@@ -40,9 +40,9 @@
       <p>接下來，讓 Git 知道這台電腦所做的修改該連結到什麼使用者：</p>
 
       <p>設定你的名字：</p>
-      <p><code>$ git config --global user.name "&#60;Your Name&#62;"</code></p>
+      <p><code class="shell">git config --global user.name "&#60;Your Name&#62;"</code></p>
       <p>設定你的電子信箱：</p>
-      <p><code>$ git config --global user.email "&#60;youremail@example.com&#62;"</code></p>
+      <p><code class="shell">git config --global user.email "&#60;youremail@example.com&#62;"</code></p>
 
 {{{verify_button}}}
 

--- a/challenge-content-zhtw/2_repository.html
+++ b/challenge-content-zhtw/2_repository.html
@@ -27,13 +27,13 @@
       <p>你可以將下列指令一一輸入至終端機。</p>
 
       <p>建立新資料夾：</p>
-      <code>$ mkdir hello-world</code>
+      <code class="shell">mkdir hello-world</code>
 
       <p>進入這個資料夾：</p>
-      <code>$ cd hello-world</code>
+      <code class="shell">cd hello-world</code>
 
       <p>把這個資料夾設定成一個 Git 專案資料夾</p>
-      <code>$ git init</code>
+      <code class="shell">git init</code>
 
       <p>就是這樣！終端機會回應並切換到下一行。如果你想要確認此資料夾是否已經是個 Git <n>repository</n>，輸入 <code>git status</code>，只要不是顯示 'fatal: Not a git repository...'，那就對了！</p>
 
@@ -43,12 +43,12 @@
         <h2>撇步</h2>
         <ul>
           <li><strong>建立一個新資料夾 (或稱做目錄)</strong></li>
-          <code>$ mkdir &#60;FOLDERNAME&#62;</code>
+          <code class="shell">mkdir &#60;FOLDERNAME&#62;</code>
           <li><strong>進入一個資料夾 (或稱做切換目錄)</strong></li>
-          <code>$ cd &#60;FOLDERNAME&#62;</code>
+          <code class="shell">cd &#60;FOLDERNAME&#62;</code>
           <li><strong>列出資料夾內容</strong></li>
-          <code>$ ls </code>
+          <code class="shell">ls </code>
           <li><strong>為一個資料夾加上 Git 功能</strong></li>
-          <code>$ git init</code>
+          <code class="shell">git init</code>
         </ul>
       </div>

--- a/challenge-content-zhtw/3_commit_to_it.html
+++ b/challenge-content-zhtw/3_commit_to_it.html
@@ -12,15 +12,15 @@
       <h2>步驟：<n>status</n>、<v>add</v> 及 <v>commit</v> 修改</h2>
       <p>接著檢查你的 <n>repository</n> 的 <strong><n>status</n></strong>，看看是否在裡頭有任何修改。回到你的終端機，應該還在你剛剛所建立的 'hello-world' 資料夾裡頭，直接用這個指令查看狀態：</p>
 
-      <p><code>$ git status</code></p>
+      <p><code class="shell">git status</code></p>
 
       <p>接著將剛剛建立檔案，<v>add</v> 進你想 <strong><v>commit</v></strong>（或儲存）的修改。
 
-      <p><code>$ git add readme.txt</code></p>
+      <p><code class="shell">git add readme.txt</code></p>
 
       <p>最後，將那些修改 <v><strong>commit</strong></v> 到 <n>repository</n> 的歷史紀錄當中，並隨附上一個簡短的異動說明。</p>
 
-      <p><code>$ git commit -m "&#60;your commit message&#62;"</code></p>
+      <p><code class="shell">git commit -m "&#60;your commit message&#62;"</code></p>
 
       <h2>步驟：進行更多修改</h2>
 
@@ -28,7 +28,7 @@
 
       <p>在終端機裡你可以查看有那些 <strong><n>diff</n></strong> 存在於現在的檔案以及上次你所 <v>commit</v> 的檔案之間。</p>
 
-      <p><code>$ git diff</code></p>
+      <p><code class="shell">git diff</code></p>
 
       <p>利用你剛剛所學到的知識，<v>commit</v> 這個最新的修改。</p>
 
@@ -38,14 +38,14 @@
         <h2>撇步</h2>
         <ul>
           <li><strong>檢查 <n>repository</n> 中的修改 <n>status</n></strong></li>
-          <li><code>$ git status</code></li>
+          <li><code class="shell">git status</code></li>
           <li><strong>查看對檔案的修改</strong></li>
-          <li><code>$ git diff</code></li>
+          <li><code class="shell">git diff</code></li>
           <li><strong>準備 <v>commit</v> 對於一個檔案的修改</strong></li>
-          <li><code>$ git add &#60;FILENAME&#62;</code></li>
+          <li><code class="shell">git add &#60;FILENAME&#62;</code></li>
           <li><strong>準備 <v>commit</v> 對於所有檔案的修改</strong></li>
-          <li><code>$ git add .</code></li>
+          <li><code class="shell">git add .</code></li>
           <li><strong><v>commit</v>(或儲存）您所準備好的修改並附上一個簡短的異動說明</strong></li>
-          <li><code>$ git commit -m "&#60;your commit message&#62;"</code></li>
+          <li><code class="shell">git commit -m "&#60;your commit message&#62;"</code></li>
         <ul>
       </div>

--- a/challenge-content-zhtw/4_githubbin.html
+++ b/challenge-content-zhtw/4_githubbin.html
@@ -19,7 +19,7 @@
 
       <p>告訴 Git 你的 GitHub 帳號：</p>
 
-      <code>$ git config --global user.username &#60;USerNamE&#62;</code>
+      <code class="shell">git config --global user.username &#60;USerNamE&#62;</code>
       <br><br>
 
 {{{verify_button}}}
@@ -30,6 +30,6 @@
         <h4>GitHub & Git config usernames do not match</h4>
         <p>常見的錯誤是 GitHub 帳號跟 <code>git config</code> 設定的帳號沒有一致。譬如 'jlord' 跟 'JLord' 是不一樣的哦。</p>
         <p>要修改 Git 設定的帳號，只要再用一次上面教的指令，大小寫打對就可以了：</p>
-        <p><code>$ git config --global user.username &#60;USerNamE&#62;</code></p>
+        <p><code class="shell">git config --global user.username &#60;USerNamE&#62;</code></p>
         <p>更新完之後，再檢查一次看看吧！</p>
       </div>

--- a/challenge-content-zhtw/5_remote_control.html
+++ b/challenge-content-zhtw/5_remote_control.html
@@ -42,7 +42,7 @@
 
       <p>回到終端機，在我們剛剛初始化過 Git 的 'hello-world' 的資料夾裡頭，我們需要告訴 Git 這個 <n>remote</n> 的位址。同一個 Git 專案中，可以有很多不同的 <n>remote</n>，所以每一個 <n>remote</n> 都需要一個名字。而最主要、原始的那一個，通常都是叫做 <code>origin</code>。</p>
 
-      <code>$ git remote add origin &#60;URLFROMGITHUB&#62;</code>
+      <code class="shell">git remote add origin &#60;URLFROMGITHUB&#62;</code>
 
       <p>你電腦上的 <n>repository</n> 現在知道了專案有一個在 GitHub 上的 <strong><n>remote</n></strong>，叫做 'origin'。你可以想像這就好像是把一個電話號碼配上一個名字一樣，這樣當你要打電話的時候，就不用記得號碼了。</p>
 
@@ -50,7 +50,7 @@
         <p><strong>備註：</strong></p>
         <p>如果你有安裝 <strong>GitHub for Windows</strong>，Git 初始化的時候就會直接設定了一個叫做 'origin' 的 <n>remote</n>，所以你不需要新增，只要設定這個 'origin' <n>remote</n> 的位址就好了：</p>
 
-        <code>$ git remote set-url origin &#60;URLFROMGITHUB&#62;</code>
+        <code class="shell">git remote set-url origin &#60;URLFROMGITHUB&#62;</code>
       </blockquote>
 
       <h2>步驟：把你的修改 <v>Push</v> 到 <n>remote</n></h2>
@@ -61,7 +61,7 @@
 
       <p>也就是說，我們現在想要把 'master' <n>branch</n> 的程式傳送到先前新增的 'origin' <n>remote</n>。</p>
 
-      <code>$ git push origin master</code>
+      <code class="shell">git push origin master</code>
 
       <p>完成之後，你現在就可以回到 GitHub 的 <n>repository</n> 頁面，重新整理。哇哇哇！程式是不是都同步了呢？恭喜你建立了第一個公開的 <n>repository</n>！</p>
 
@@ -71,14 +71,14 @@
         <h2>撇步</h2>
         <ul>
           <li><strong>新增 <n>remote</n> 連結</strong></li>
-          <code>$ git remote add &#60;REMOTENAME&#62; <URL></code>
+          <code class="shell">git remote add &#60;REMOTENAME&#62; <URL></code>
           <li><strong>幫一個 <n>remote</n> 設定位址</strong></li>
-          <code>$ git remote set-url &#60;REMOTENAME&#62; <URL></code>
+          <code class="shell">git remote set-url &#60;REMOTENAME&#62; <URL></code>
           <li><strong><v>Pull</v> <n>remote</n> 的程式</strong></li>
-          <code>$ git pull &#60;REMOTENAME&#62; &#60;BRANCHNAME&#62;</code>
+          <code class="shell">git pull &#60;REMOTENAME&#62; &#60;BRANCHNAME&#62;</code>
           <li><strong>看你有哪些 <n>remote</n> 連結</strong></li>
-          <code>$ git remote -v</code>
+          <code class="shell">git remote -v</code>
           <li><strong><v>Push</v> 電腦上的程式到 <n>remote</n></strong></li>
-          <code>$ git push &#60;REMOTENAME&#62; <BRANCH></code>
+          <code class="shell">git push &#60;REMOTENAME&#62; <BRANCH></code>
         </ul>
       </div>

--- a/challenge-content-zhtw/6_forks_and_clones.html
+++ b/challenge-content-zhtw/6_forks_and_clones.html
@@ -20,14 +20,14 @@
       <h2>步驟：在電腦上 <v>Clone</v> <n>Fork</n></h2>
       <p>現在，在終端機 <v>clone</v> <n>repository</n> 到你的電腦上，他會自動替 <n>repository</n> 建立一個新的資料夾，所以你不需要自己建立一個。但請注意不要在另一個 Git <n>repository</n> 資料夾中 <v>clone</v>！所以，如果你還在先前挑戰所使用的 'hello-world' <n>repository</n> 中，請先離開那個資料夾。你可以透過切換資料夾指令以及兩個點來移動到資料夾的上一層：
 
-      <p><code>$ cd ..</code></p>
+      <p><code class="shell">cd ..</code></p>
 
       然後 <v>clone</v>：
 
-      <p><code>$ git clone &#60;URLFROMGITHUB&#62;</code></p>
+      <p><code class="shell">git clone &#60;URLFROMGITHUB&#62;</code></p>
 
       <p>切換到剛剛建立的 <n>fork</n> 資料夾（在這個例子中叫做 'patchwork'）：</p>
-      <p><code>$ cd patchwork</code></p>
+      <p><code class="shell">cd patchwork</code></p>
 
       <p>現在你已經在電腦上得到了一份 <n>repository</n> 的副本，並且被自動連接到你 GitHub 帳號下的 <n>remote</n> <n>repository</n>（你的 <n>fork</n> 副本）。</p>
 
@@ -37,7 +37,7 @@
 
       <p>你可以隨意替這個 <n>remote</n> 連結命名，但大家通常用 'upstream'，讓我們也用這個名字：</p>
 
-      <p><code>$ git remote add upstream https://github.com/jlord/patchwork.git</code></p>
+      <p><code class="shell">git remote add upstream https://github.com/jlord/patchwork.git</code></p>
 
 {{{verify_directory_button}}}
 
@@ -45,8 +45,8 @@
         <h2>撇步</h2>
         <ul>
           <li><strong>新增 <n>remote</n> 連結</strong></li>
-          <li><code>$ git remote add &#60;REMOTENAME&#62; &#60;URL&#62;</code></li>
+          <li><code class="shell">git remote add &#60;REMOTENAME&#62; &#60;URL&#62;</code></li>
           <li><strong>檢視 <n>remote</n> 連結</strong></li>
-          <li><code>$ git remote -v</code></li>
+          <li><code class="shell">git remote -v</code></li>
         </ul>
       </div>

--- a/challenge-content-zhtw/7_branches_arent_just_for_birds.html
+++ b/challenge-content-zhtw/7_branches_arent_just_for_birds.html
@@ -23,14 +23,14 @@
 
       <p>新增一個 <n>branch</n> 並命名為「add-&#60;username&#62;」，請用你的帳號名稱替換掉 'username'。例如「add-jlord」。<strong><n>Branches</n> 的名字有分大小寫，所以請確定輸入的帳號名稱跟 GitHub 上顯示的一模一樣。</strong></p>
 
-      <p><code>$ git branch &#60;BRANCHNAME&#62;</code></p>
+      <p><code class="shell">git branch &#60;BRANCHNAME&#62;</code></p>
 
       <p>水啦！你擁有了一個全新、內容跟 'gh-pages' 一模一樣的 <n>branch</n>！</p>
 
       <p>就像終端機去另一個資料夾的指令 <code>cd</code> 一樣，請 <strong><v>checkout</v></strong>
         到剛才新增的 <n>branch</n>：</p>
 
-      <p><code>$ git checkout &#60;BRANCHNAME&#62;</code></p>
+      <p><code class="shell">git checkout &#60;BRANCHNAME&#62;</code></p>
 
       <h2>步驟：新增檔案</h2>
       <p>接下來我們回到文字編輯器：</p>
@@ -44,13 +44,13 @@
       <h2>步驟：紀錄</h2>
       <p>按照以下的步驟，把剛才的修改用 Git 記錄下來：</p>
 
-      <p><code>$ git status</code></p>
-      <p><code>$ git add &#60;FILENAME&#62;</code></p>
-      <p><code>$ git commit -m "&#60;commit message&#62;"</code></p>
+      <p><code class="shell">git status</code></p>
+      <p><code class="shell">git add &#60;FILENAME&#62;</code></p>
+      <p><code class="shell">git commit -m "&#60;commit message&#62;"</code></p>
 
       <p><v>Push</v> 剛才記錄好的修改到 GitHub 上，你 <adj>forked</adj> 的 <n>repository</n> 裡頭：</p>
 
-      <p><code>$ git push origin &#60;BRANCHNAME&#62;</code></p>
+      <p><code class="shell">git push origin &#60;BRANCHNAME&#62;</code></p>
 
 {{{verify_directory_button}}}
 
@@ -61,12 +61,12 @@
         <p>剛才新增的檔案應該要放到 Patchwork <n>repository</n> 的 'contributors'
           資料夾裡。如果不小心放到別的地方，請打開 Finder 或是 Windows 的檔案總管將該檔案移到
           'contributors' 資料夾，然後可以用 <code>git status</code> 看你剛才移動檔案之後所造成的結果。用以下的指令 <v>Stage</v> 並且 <v>commit</v> 全部的修改（加上 -A，會將新增檔案跟刪除檔案的動作一起記錄下來）：</p>
-        <p><code>$ git add -A</code></p>
-        <p><code>$ git commit -m "move file into contributors folder"</code></p>
+        <p><code class="shell">git add -A</code></p>
+        <p><code class="shell">git commit -m "move file into contributors folder"</code></p>
 
         <h4><n>Branch</n> name expected: _____</h4>
         <p><n>Branch</n> 的名字應該要跟你的帳號名稱一模一樣。用以下的指令修改 <n>branch</n> 的名字：</p>
-        <p><code>$ git branch -M &#60;NEWBRANCHNAME&#62;</code></p>
+        <p><code class="shell">git branch -M &#60;NEWBRANCHNAME&#62;</code></p>
         <p>完成以上的動作之後，再執行一次 <code>git-it verify</code>！</p>
       </div>
 
@@ -74,16 +74,16 @@
         <h2>撇步</h2>
         <ul>
           <li>只用一個指令就新增並切換到新的 <n>branch</n></li>
-          <li><code>$ git checkout -b &#60;BRANCHNAME&#62;</code></li>
+          <li><code class="shell">git checkout -b &#60;BRANCHNAME&#62;</code></li>
           <li>新增 <n>branch</n></li>
-          <li><code>$ git branch &#60;BRANCHNAME&#62;</code></li>
+          <li><code class="shell">git branch &#60;BRANCHNAME&#62;</code></li>
           <li>切換到另一個 <n>branch</n></li>
-          <li><code>$ git checkout &#60;BRANCHNAME&#62;</code></li>
+          <li><code class="shell">git checkout &#60;BRANCHNAME&#62;</code></li>
           <li>列出所有的 <n>branches</n></li>
-          <li><code>$ git branch</code></li>
+          <li><code class="shell">git branch</code></li>
           <li>重新命名目前所在的 <n>branch</n></li>
-          <li><code>$ git branch -m &#60;NEWBRANCHNAME&#62;</code></li>
+          <li><code class="shell">git branch -m &#60;NEWBRANCHNAME&#62;</code></li>
           <li>看目前正在哪個 <n>branch</n></li>
-          <li><code>$ git status</code></li>
+          <li><code class="shell">git status</code></li>
         </ul>
       </div>

--- a/challenge-content-zhtw/9_pull_never_out_of_date.html
+++ b/challenge-content-zhtw/9_pull_never_out_of_date.html
@@ -12,7 +12,7 @@
 
       <p>把 GitHub 上 'origin' <n>remote</n> 的更新 <v>pull</v> 到你的電腦上，來看 Reporobot 是否有在 'add-' <n>branch</n> 做了任何修改：</p>
 
-      <p><code>$ git pull &#60;REMOTENAME&#62; &#60;BRANCHNAME&#62;</code></p>
+      <p><code class="shell">git pull &#60;REMOTENAME&#62; &#60;BRANCHNAME&#62;</code></p>
 
       <p>如果沒有任何修改，Git 會告訴你 'Already up-to-date'。若有修改的話，Git 會把那些修改 <v>merge</v> 到電腦裡哦。</p>
 
@@ -24,10 +24,10 @@
         <h2>撇步</h2>
           <ul>
           <li><strong>檢查 Git 狀態</strong></li>
-          <code>$ git status</code>
+          <code class="shell">git status</code>
           <li><strong>從遠端分支 <v>pull</v> 更新回來</strong></li>
-          <code>$ git pull <REMOTENAME> <REMOTEBRANCH></code>
+          <code class="shell">git pull <REMOTENAME> <REMOTEBRANCH></code>
           <li><strong>在收取更新前先檢查 <n>remote</n> 是否有變動</strong></li>
-          <code>$ git fetch --dry-run</code>
+          <code class="shell">git fetch --dry-run</code>
         </ul>
       </div>

--- a/challenge-content/11_merge_tada.html
+++ b/challenge-content/11_merge_tada.html
@@ -13,18 +13,18 @@
 <p>First, move into the branch you want to merge <em>into</em> — in this case,
   branch 'gh-pages'.</p>
 
-<p><code>$ git checkout gh-pages</code></p>
+<p><code class="shell">git checkout gh-pages</code></p>
 
 <p>Now tell Git what branch you want to merge <em>in</em> — in this case,
   your feature branch that begins with "add-".</p>
 
-<p><code>$ git merge &#60;BRANCHNAME&#62;</code></p>
+<p><code class="shell">git merge &#60;BRANCHNAME&#62;</code></p>
 
 <p>Tidy up by deleting your feature branch now that it has been merged.</p>
-<p><code>$ git branch -d &#60;BRANCHNAME&#62;</code></p>
+<p><code class="shell">git branch -d &#60;BRANCHNAME&#62;</code></p>
 
 <p>You can also delete the branch from your fork on GitHub:</p>
-<p><code>$ git push &#60;REMOTENAME&#62; --delete &#60;BRANCHNAME&#62;</code></p>
+<p><code class="shell">git push &#60;REMOTENAME&#62; --delete &#60;BRANCHNAME&#62;</code></p>
 
 <h2>Step: Pull from Upstream</h2>
 <p>And last but not least, if you pull in updates from the original
@@ -33,7 +33,7 @@
 
 <p>To pull from the original upstream:</p>
 
-<p><code>$ git pull upstream gh-pages</code></p>
+<p><code class="shell">git pull upstream gh-pages</code></p>
 
 <h2>Congratulations!</h2>
 <p>You've created local repositories, remote repositories, worked with
@@ -47,14 +47,14 @@
   <h2>Tips</h2>
   <ul>
     <li><strong>Merge a branch into current branch</strong></li>
-    <code>$ git merge &#60;BRANCHNAME&#62;</code>
+    <code class="shell">git merge &#60;BRANCHNAME&#62;</code>
     <li><strong>Change the branch you're working on</strong></li>
-    <code>$ git checkout &#60;BRANCHNAME&#62;</code>
+    <code class="shell">git checkout &#60;BRANCHNAME&#62;</code>
     <li><strong>Delete a local branch</strong></li>
-    <code>$ git branch -d &#60;BRANCHNAME&#62;</code>
+    <code class="shell">git branch -d &#60;BRANCHNAME&#62;</code>
     <li><strong>Delete a remote branch</strong></li>
-    <code>$ git push &#60;REMOTENAME&#62; --delete &#60;BRANCHNAME&#62;</code>
+    <code class="shell">git push &#60;REMOTENAME&#62; --delete &#60;BRANCHNAME&#62;</code>
     <li><strong>Pull from a remote branch</strong></li>
-    <code>$ git pull &#60;REMOTENAME&#62; &#60;BRANCHNAME&#62;</code>
+    <code class="shell">git pull &#60;REMOTENAME&#62; &#60;BRANCHNAME&#62;</code>
   </ul>
 </div>

--- a/challenge-content/1_get_git.html
+++ b/challenge-content/1_get_git.html
@@ -36,7 +36,7 @@ terminal (which you're using in Git-it!) or Git desktop applications (like GitHu
 <p>Once it is installed, open <strong>terminal</strong> (aka Bash, aka Shell, aka Prompt).
 You can verify that it's really there by typing:</p>
 
-<p><code>$ git --version </code></p>
+<p><code class="shell">git --version </code></p>
 
 <p>This will return the version of Git that you're running and look something like this:</p>
 
@@ -47,9 +47,9 @@ You can verify that it's really there by typing:</p>
 <p>Next, configure Git so it knows who to associate your changes to:</p>
 
 <p>Set your name:</p>
-<p><code>$ git config --global user.name "&#60;Your Name&#62;"</code></p>
+<p><code class="shell">git config --global user.name "&#60;Your Name&#62;"</code></p>
 <p>Now set your email:</p>
-<p><code>$ git config --global user.email "&#60;youremail@example.com&#62;"</code></p>
+<p><code class="shell">git config --global user.email "&#60;youremail@example.com&#62;"</code></p>
 
 {{{verify_button}}}
 

--- a/challenge-content/2_repository.html
+++ b/challenge-content/2_repository.html
@@ -32,13 +32,13 @@
 <p>You can type these commands one at a time into your terminal window.</p>
 
 <p>To make a new folder:</p>
-<code>$ mkdir hello-world</code>
+<code class="shell">mkdir hello-world</code>
 
 <p>To go into that folder:</p>
-<code>$ cd hello-world</code>
+<code class="shell">cd hello-world</code>
 
 <p>To create a new Git instance for a project:</p>
-<code>$ git init</code>
+<code class="shell">git init</code>
 
 <p>That's it! It will just return you to a new line. If you want to be double-sure that it's a Git repository, type <code>git status</code> and if it doesn't return 'fatal: Not a git repository...', you're golden!</p>
 
@@ -48,12 +48,12 @@
   <h2>Tips</h2>
   <ul>
     <li><strong>Make a new folder (aka directory)</strong></li>
-    <code>$ mkdir &#60;FOLDERNAME&#62;</code>
+    <code class="shell">mkdir &#60;FOLDERNAME&#62;</code>
     <li><strong>Navigate into an existing folder (aka change directory)</strong></li>
-    <code>$ cd &#60;FOLDERNAME&#62;</code>
+    <code class="shell">cd &#60;FOLDERNAME&#62;</code>
     <li><strong>List the items in a folder</strong></li>
-    <code>$ ls </code>
+    <code class="shell">ls </code>
     <li><strong>Turn Git on for a folder</strong></li>
-    <code>$ git init</code>
+    <code class="shell">git init</code>
   </ul>
 </div>

--- a/challenge-content/3_commit_to_it.html
+++ b/challenge-content/3_commit_to_it.html
@@ -16,16 +16,16 @@
   you should still be within the 'hello-world' you created. See if there
   are changes listed:</p>
 
-<p><code>$ git status</code></p>
+<p><code class="shell">git status</code></p>
 
 <p>Then <strong>add</strong> the file you just created to the files you'd
   like to <strong>commit</strong> (aka save) to change. </p>
 
-<p><code>$ git add readme.txt</code></p>
+<p><code class="shell">git add readme.txt</code></p>
 
 <p>Finally, <strong>commit</strong> those changes to the repository's history with a
   short description of the updates.</p>
-<p><code>$ git commit -m "&#60;your commit message&#62;"</code></p>
+<p><code class="shell">git commit -m "&#60;your commit message&#62;"</code></p>
 
 <h2>Step: Make More Changes</h2>
 <p>Now add another line to <code>readme.txt</code> and save.</p>
@@ -33,7 +33,7 @@
 <p>In terminal, you can view the <strong>diff</strong>erence between the
   file now and how it was at your last commit. </p>
 
-<p><code>$ git diff</code></p>
+<p><code class="shell">git diff</code></p>
 
 <p>Now with what you just learned above, commit this latest change.</p>
 
@@ -43,14 +43,14 @@
   <h2>Tips</h2>
   <ul>
     <li><strong>Check status of changes to a repository</strong></li>
-    <li><code>$ git status</code></li>
+    <li><code class="shell">git status</code></li>
     <li><strong>View changes to files</strong></li>
-    <li><code>$ git diff</code></li>
+    <li><code class="shell">git diff</code></li>
     <li><strong>Add a file's changes to be committed</strong></li>
-    <li><code>$ git add &#60;FILENAME&#62;</code></li>
+    <li><code class="shell">git add &#60;FILENAME&#62;</code></li>
     <li><strong>To add all files changes</strong></li>
-    <li><code>$ git add .</code></li>
+    <li><code class="shell">git add .</code></li>
     <li><strong>To commit (aka save) the changes you've added with a short message describing the changes</strong></li>
-    <li><code>$ git commit -m "&#60;your commit message&#62;"</code></li>
+    <li><code class="shell">git commit -m "&#60;your commit message&#62;"</code></li>
   <ul>
 </div>

--- a/challenge-content/4_githubbin.html
+++ b/challenge-content/4_githubbin.html
@@ -22,7 +22,7 @@ which will be needed in order to verify the upcoming challenges. Save it exactly
 
 <p>Add your GitHub username to your configuration:</p>
 
-<code>$ git config --global user.username &#60;USerNamE&#62;</code>
+<code class="shell">git config --global user.username &#60;USerNamE&#62;</code>
 <br><br>
 
 {{{verify_button}}}
@@ -33,6 +33,6 @@ which will be needed in order to verify the upcoming challenges. Save it exactly
   <h4>GitHub & Git config usernames do not match</h4>
   <p>A common error is not having your GitHub username match the case of the one you set with <code>git config</code>. For instance, 'JLord' isn't the same as 'jlord'</p>
   <p>To change your username set with Git, just do the same command you did earlier, but with the correct capitalization:</p>
-  <p><code>$ git config --global user.username &#60;USerNamE&#62;</code></p>
+  <p><code class="shell">git config --global user.username &#60;USerNamE&#62;</code></p>
   <p>When you've made your updates, verify again!</p>
 </div>

--- a/challenge-content/5_remote_control.html
+++ b/challenge-content/5_remote_control.html
@@ -55,7 +55,7 @@ repository on GitHub's servers.</p>
 initialized as a Git repository in the earlier challenge, you
 want to tell Git the location of the remote version on GitHub's servers. You can have multiple remotes so each requires a name. For your main one, this is commonly named <code>origin</code>.</p>
 
-<code>$ git remote add origin &lt;URLFROMGITHUB&gt;</code>
+<code class="shell">git remote add origin &lt;URLFROMGITHUB&gt;</code>
 
 <p>Your <strong>local</strong> repository now knows where your <strong>remote</strong> one named 'origin' lives on GitHub's servers. Think of it as adding a name and address on speed dial — now when you need to send something there, you can.</p>
 
@@ -66,7 +66,7 @@ want to tell Git the location of the remote version on GitHub's servers. You can
   just need to tell it what URL to associate with origin. Use this
   command instead of the 'add' one above:</p>
 
-<code>$ git remote set-url origin &lt;URLFROMGITHUB&gt;</code>
+<code class="shell">git remote set-url origin &lt;URLFROMGITHUB&gt;</code>
 </blockquote>
 
 <h2>Step: Push Work to your Remote</h2>
@@ -81,7 +81,7 @@ want to tell Git the location of the remote version on GitHub's servers. You can
 
 <p>In this case, we'll send our branch named 'master' to our remote on GitHub named 'origin'. </p>
 
-<code>$ git push origin master</code>
+<code class="shell">git push origin master</code>
 
 <p>Now go to GitHub and refresh the page of your repository. WOAH!
   Everything is the same locally and remotely. Congrats on your
@@ -93,14 +93,14 @@ want to tell Git the location of the remote version on GitHub's servers. You can
   <h2>Tips</h2>
   <ul>
     <li><strong>Add remote connections</strong></li>
-    <code>$ git remote add &lt;REMOTENAME&gt; &lt;URL&gt;</code>
+    <code class="shell">git remote add &lt;REMOTENAME&gt; &lt;URL&gt;</code>
     <li><strong>Set a URL to a remote</strong></li>
-    <code>$ git remote set-url &lt;REMOTENAME&gt; &lt;URL&gt;</code>
+    <code class="shell">git remote set-url &lt;REMOTENAME&gt; &lt;URL&gt;</code>
     <li><strong>Pull in changes</strong></li>
-    <code>$ git pull &lt;REMOTENAME&gt; &lt;BRANCHNAME&gt;</code>
+    <code class="shell">git pull &lt;REMOTENAME&gt; &lt;BRANCHNAME&gt;</code>
     <li><strong>View remote connections</strong></li>
-    <code>$ git remote -v</code>
+    <code class="shell">git remote -v</code>
     <li><strong>Push changes</strong></li>
-    <code>$ git push &lt;REMOTENAME&gt; &lt;BRANCH&gt;</code>
+    <code class="shell">git push &lt;REMOTENAME&gt; &lt;BRANCH&gt;</code>
   </ul>
 </div>

--- a/challenge-content/6_forks_and_clones.html
+++ b/challenge-content/6_forks_and_clones.html
@@ -31,14 +31,14 @@
   inside of the 'hello-world' repository you worked in on the earlier challenges,
   back out of that folder. You can leave the folder you're in (and be in the folder that it was inside of) by 'changing directory' with two dots:
 
-<p><code>$ cd ..</code></p>
+<p><code class="shell">cd ..</code></p>
 
 Now clone:
 
-<p><code>$ git clone &#60;URLFROMGITHUB&#62;</code></p>
+<p><code class="shell">git clone &#60;URLFROMGITHUB&#62;</code></p>
 
 <p>Go into the folder for the fork it created (in this case, named 'patchwork')</p>
-<p><code>$ cd patchwork</code></p>
+<p><code class="shell">cd patchwork</code></p>
 
 <p>Now you've got a copy of the repository on your computer and it is
   automatically connected to the remote repository (your forked copy)
@@ -54,7 +54,7 @@ Now clone:
 <p>You can name this remote connection anything you want, but often
   people use 'upstream', let's use that for this.</p>
 
-<p><code>$ git remote add upstream https://github.com/jlord/patchwork.git</code></p>
+<p><code class="shell">git remote add upstream https://github.com/jlord/patchwork.git</code></p>
 
 {{{verify_directory_button}}}
 
@@ -62,8 +62,8 @@ Now clone:
   <h2>Tips</h2>
   <ul>
     <li><strong>Add remote connections</strong></li>
-    <li><code>$ git remote add &#60;REMOTENAME&#62; &#60;URL&#62;</code></li>
+    <li><code class="shell">git remote add &#60;REMOTENAME&#62; &#60;URL&#62;</code></li>
     <li><strong>View remote connections</strong></li>
-    <li><code>$ git remote -v</code></li>
+    <li><code class="shell">git remote -v</code></li>
   </ul>
 </div>

--- a/challenge-content/7_branches_arent_just_for_birds.html
+++ b/challenge-content/7_branches_arent_just_for_birds.html
@@ -35,14 +35,14 @@ GitHub Guide: <a href="http://guides.github.com/overviews/flow/" target="_blank"
 <p>Create a branch and name it "add-&#60;username&#62;", where 'username' is
   your username. For instance, "add-jlord". <strong>Branches are case-sensitive so name your branch exactly the way your GitHub name appears</strong>.</p>
 
-<p><code>$ git branch &#60;BRANCHNAME&#62;</code></p>
+<p><code class="shell">git branch &#60;BRANCHNAME&#62;</code></p>
 
 <p>Now you have a branch with a new name identical to 'gh-pages'.</p>
 
 <p>To go into that branch and work on it, similar to using <code>cd</code> to
   change directory in terminal, you <strong>checkout</strong> a branch. Go onto your new branch:</p>
 
-<p><code>$ git checkout &#60;BRANCHNAME&#62;</code></p>
+<p><code class="shell">git checkout &#60;BRANCHNAME&#62;</code></p>
 
 <h2>Step: Create a new file</h2>
 <p>Back to the text editor:</p>
@@ -58,13 +58,13 @@ GitHub Guide: <a href="http://guides.github.com/overviews/flow/" target="_blank"
 <h2>Step: Check-in</h2>
 <p>Go through the steps for checking in a project: </p>
 
-<p><code>$ git status</code></p>
-<p><code>$ git add &#60;FILENAME&#62;</code></p>
-<p><code>$ git commit -m "&#60;commit message&#62;"</code></p>
+<p><code class="shell">git status</code></p>
+<p><code class="shell">git add &#60;FILENAME&#62;</code></p>
+<p><code class="shell">git commit -m "&#60;commit message&#62;"</code></p>
 
 <p>Now push your update to your fork on GitHub:</p>
 
-<p><code>$ git push origin &#60;BRANCHNAME&#62;</code></p>
+<p><code class="shell">git push origin &#60;BRANCHNAME&#62;</code></p>
 
 {{{verify_directory_button}}}
 
@@ -73,12 +73,12 @@ GitHub Guide: <a href="http://guides.github.com/overviews/flow/" target="_blank"
 
   <h4>File NOT in contributors folder</h4>
   <p>The file you create should inside the existing 'contributors' folder in the Patchwork repository. If you put it somewhere else, simply use Finder or Windows Explorer to move your file into the folder. You can check <code>git status</code> again and you'll find it sees your changes. Stage and then commit "all" (-A) of these changes (additions and deletions) with the commands below.</p>
-  <p><code>$ git add -A</code></p>
-  <p><code>$ git commit -m "move file into contributors folder"</code></p>
+  <p><code class="shell">git add -A</code></p>
+  <p><code class="shell">git commit -m "move file into contributors folder"</code></p>
 
   <h4>Branch name expected: _____</h4>
   <p>The branch name should match your user name exactly. To change your branch name:</p>
-  <p><code>$ git branch -M &#60;NEWBRANCHNAME&#62;</code></p>
+  <p><code class="shell">git branch -M &#60;NEWBRANCHNAME&#62;</code></p>
   <p>When you've made your updates, verify again!</p>
 </div>
 
@@ -86,16 +86,16 @@ GitHub Guide: <a href="http://guides.github.com/overviews/flow/" target="_blank"
   <h2>Tips</h2>
   <ul>
     <li>You can create and switch to a branch in one line:</li>
-    <li><code>$ git checkout -b &#60;BRANCHNAME&#62;</code></li>
+    <li><code class="shell">git checkout -b &#60;BRANCHNAME&#62;</code></li>
     <li>Create a new branch:</li>
-    <li><code>$ git branch &#60;BRANCHNAME&#62;</code></li>
+    <li><code class="shell">git branch &#60;BRANCHNAME&#62;</code></li>
     <li>Move onto a branch:</li>
-    <li><code>$ git checkout &#60;BRANCHNAME&#62;</code></li>
+    <li><code class="shell">git checkout &#60;BRANCHNAME&#62;</code></li>
     <li>List the branches:</li>
-    <li><code>$ git branch</code></li>
+    <li><code class="shell">git branch</code></li>
     <li>Rename a branch you're currently on:</li>
-    <li><code>$ git branch -m &#60;NEWBRANCHNAME&#62;</code></li>
+    <li><code class="shell">git branch -m &#60;NEWBRANCHNAME&#62;</code></li>
     <li>Verify what branch you're working on</li>
-    <li><code>$ git status</code></li>
+    <li><code class="shell">git status</code></li>
   </ul>
 </div>

--- a/challenge-content/9_pull_never_out_of_date.html
+++ b/challenge-content/9_pull_never_out_of_date.html
@@ -14,7 +14,7 @@
 <p>See if Reporobot has made any changes to your 'add-' branch by pulling
   in from the remote named 'origin' on GitHub:</p>
 
-<p><code>$ git pull &lt;REMOTENAME&gt; &lt;BRANCHNAME&gt;</code></p>
+<p><code class="shell">git pull &lt;REMOTENAME&gt; &lt;BRANCHNAME&gt;</code></p>
 
 <p>If nothing's changed, it will tell you 'Already up-to-date'.
   If there are changes, it will merge those changes into your local
@@ -30,10 +30,10 @@
   <h2>TIPS</h2>
     <ul>
     <li><strong>Check Git status</strong></li>
-    <code>$ git status</code>
+    <code class="shell">git status</code>
     <li><strong>Pull in changes from a remote branch</strong></li>
-    <code>$ git pull &lt;REMOTENAME&gt; &lt;REMOTEBRANCH&gt;</code>
+    <code class="shell">git pull &lt;REMOTENAME&gt; &lt;REMOTEBRANCH&gt;</code>
     <li><strong>See changes to the remote before you pull in</strong></li>
-    <code>$ git fetch --dry-run</code>
+    <code class="shell">git fetch --dry-run</code>
   </ul>
 </div>

--- a/challenges-zhtw/branches_arent_just_for_birds.html
+++ b/challenges-zhtw/branches_arent_just_for_birds.html
@@ -144,14 +144,14 @@
 
       <p>&#x65B0;&#x589E;&#x4E00;&#x500B; <n><span class="superscript">&#x5206;&#x652F;</span>branch</n> &#x4E26;&#x547D;&#x540D;&#x70BA;&#x300C;add-&lt;username&gt;&#x300D;&#xFF0C;&#x8ACB;&#x7528;&#x4F60;&#x7684;&#x5E33;&#x865F;&#x540D;&#x7A31;&#x66FF;&#x63DB;&#x6389; &apos;username&apos;&#x3002;&#x4F8B;&#x5982;&#x300C;add-jlord&#x300D;&#x3002;<strong><n><span class="superscript">&#x5206;&#x652F;</span>Branches</n> &#x7684;&#x540D;&#x5B57;&#x6709;&#x5206;&#x5927;&#x5C0F;&#x5BEB;&#xFF0C;&#x6240;&#x4EE5;&#x8ACB;&#x78BA;&#x5B9A;&#x8F38;&#x5165;&#x7684;&#x5E33;&#x865F;&#x540D;&#x7A31;&#x8DDF; GitHub &#x4E0A;&#x986F;&#x793A;&#x7684;&#x4E00;&#x6A21;&#x4E00;&#x6A23;&#x3002;</strong></p>
 
-      <p><code>$ git branch &lt;BRANCHNAME&gt;</code></p>
+      <p><code class="shell">git branch &lt;BRANCHNAME&gt;</code></p>
 
       <p>&#x6C34;&#x5566;&#xFF01;&#x4F60;&#x64C1;&#x6709;&#x4E86;&#x4E00;&#x500B;&#x5168;&#x65B0;&#x3001;&#x5167;&#x5BB9;&#x8DDF; &apos;gh-pages&apos; &#x4E00;&#x6A21;&#x4E00;&#x6A23;&#x7684; <n><span class="superscript">&#x5206;&#x652F;</span>branch</n>&#xFF01;</p>
 
       <p>&#x5C31;&#x50CF;&#x7D42;&#x7AEF;&#x6A5F;&#x53BB;&#x53E6;&#x4E00;&#x500B;&#x8CC7;&#x6599;&#x593E;&#x7684;&#x6307;&#x4EE4; <code>cd</code> &#x4E00;&#x6A23;&#xFF0C;&#x8ACB; <strong><v><span class="superscript">&#x53D6;&#x51FA;</span>checkout</v></strong>
         &#x5230;&#x525B;&#x624D;&#x65B0;&#x589E;&#x7684; <n><span class="superscript">&#x5206;&#x652F;</span>branch</n>&#xFF1A;</p>
 
-      <p><code>$ git checkout &lt;BRANCHNAME&gt;</code></p>
+      <p><code class="shell">git checkout &lt;BRANCHNAME&gt;</code></p>
 
       <h2>&#x6B65;&#x9A5F;&#xFF1A;&#x65B0;&#x589E;&#x6A94;&#x6848;</h2>
       <p>&#x63A5;&#x4E0B;&#x4F86;&#x6211;&#x5011;&#x56DE;&#x5230;&#x6587;&#x5B57;&#x7DE8;&#x8F2F;&#x5668;&#xFF1A;</p>
@@ -165,13 +165,13 @@
       <h2>&#x6B65;&#x9A5F;&#xFF1A;&#x7D00;&#x9304;</h2>
       <p>&#x6309;&#x7167;&#x4EE5;&#x4E0B;&#x7684;&#x6B65;&#x9A5F;&#xFF0C;&#x628A;&#x525B;&#x624D;&#x7684;&#x4FEE;&#x6539;&#x7528; Git &#x8A18;&#x9304;&#x4E0B;&#x4F86;&#xFF1A;</p>
 
-      <p><code>$ git status</code></p>
-      <p><code>$ git add &lt;FILENAME&gt;</code></p>
-      <p><code>$ git commit -m &quot;&lt;commit message&gt;&quot;</code></p>
+      <p><code class="shell">git status</code></p>
+      <p><code class="shell">git add &lt;FILENAME&gt;</code></p>
+      <p><code class="shell">git commit -m &quot;&lt;commit message&gt;&quot;</code></p>
 
       <p><v><span class="superscript">&#x63A8;&#x9001;</span>Push</v> &#x525B;&#x624D;&#x8A18;&#x9304;&#x597D;&#x7684;&#x4FEE;&#x6539;&#x5230; GitHub &#x4E0A;&#xFF0C;&#x4F60; <adj><span class="superscript">&#x8907;&#x672C;&#x7684;</span>forked</adj> &#x7684; <n><span class="superscript">&#x7A0B;&#x5F0F;&#x5EAB;</span>repository</n> &#x88E1;&#x982D;&#xFF1A;</p>
 
-      <p><code>$ git push origin &lt;BRANCHNAME&gt;</code></p>
+      <p><code class="shell">git push origin &lt;BRANCHNAME&gt;</code></p>
 
 <div class="verify">
   <button class="white" id="verify-challenge">VERIFY</button>
@@ -190,12 +190,12 @@
         <p>&#x525B;&#x624D;&#x65B0;&#x589E;&#x7684;&#x6A94;&#x6848;&#x61C9;&#x8A72;&#x8981;&#x653E;&#x5230; Patchwork <n><span class="superscript">&#x7A0B;&#x5F0F;&#x5EAB;</span>repository</n> &#x7684; &apos;contributors&apos;
           &#x8CC7;&#x6599;&#x593E;&#x88E1;&#x3002;&#x5982;&#x679C;&#x4E0D;&#x5C0F;&#x5FC3;&#x653E;&#x5230;&#x5225;&#x7684;&#x5730;&#x65B9;&#xFF0C;&#x8ACB;&#x6253;&#x958B; Finder &#x6216;&#x662F; Windows &#x7684;&#x6A94;&#x6848;&#x7E3D;&#x7BA1;&#x5C07;&#x8A72;&#x6A94;&#x6848;&#x79FB;&#x5230;
           &apos;contributors&apos; &#x8CC7;&#x6599;&#x593E;&#xFF0C;&#x7136;&#x5F8C;&#x53EF;&#x4EE5;&#x7528; <code>git status</code> &#x770B;&#x4F60;&#x525B;&#x624D;&#x79FB;&#x52D5;&#x6A94;&#x6848;&#x4E4B;&#x5F8C;&#x6240;&#x9020;&#x6210;&#x7684;&#x7D50;&#x679C;&#x3002;&#x7528;&#x4EE5;&#x4E0B;&#x7684;&#x6307;&#x4EE4; <v><span class="superscript">&#x9810;&#x5099;</span>Stage</v> &#x4E26;&#x4E14; <v><span class="superscript">&#x63D0;&#x4EA4;</span>commit</v> &#x5168;&#x90E8;&#x7684;&#x4FEE;&#x6539;&#xFF08;&#x52A0;&#x4E0A; -A&#xFF0C;&#x6703;&#x5C07;&#x65B0;&#x589E;&#x6A94;&#x6848;&#x8DDF;&#x522A;&#x9664;&#x6A94;&#x6848;&#x7684;&#x52D5;&#x4F5C;&#x4E00;&#x8D77;&#x8A18;&#x9304;&#x4E0B;&#x4F86;&#xFF09;&#xFF1A;</p>
-        <p><code>$ git add -A</code></p>
-        <p><code>$ git commit -m &quot;move file into contributors folder&quot;</code></p>
+        <p><code class="shell">git add -A</code></p>
+        <p><code class="shell">git commit -m &quot;move file into contributors folder&quot;</code></p>
 
         <h4><n><span class="superscript">&#x5206;&#x652F;</span>Branch</n> name expected: _____</h4>
         <p><n><span class="superscript">&#x5206;&#x652F;</span>Branch</n> &#x7684;&#x540D;&#x5B57;&#x61C9;&#x8A72;&#x8981;&#x8DDF;&#x4F60;&#x7684;&#x5E33;&#x865F;&#x540D;&#x7A31;&#x4E00;&#x6A21;&#x4E00;&#x6A23;&#x3002;&#x7528;&#x4EE5;&#x4E0B;&#x7684;&#x6307;&#x4EE4;&#x4FEE;&#x6539; <n><span class="superscript">&#x5206;&#x652F;</span>branch</n> &#x7684;&#x540D;&#x5B57;&#xFF1A;</p>
-        <p><code>$ git branch -M &lt;NEWBRANCHNAME&gt;</code></p>
+        <p><code class="shell">git branch -M &lt;NEWBRANCHNAME&gt;</code></p>
         <p>&#x5B8C;&#x6210;&#x4EE5;&#x4E0A;&#x7684;&#x52D5;&#x4F5C;&#x4E4B;&#x5F8C;&#xFF0C;&#x518D;&#x57F7;&#x884C;&#x4E00;&#x6B21; <code>git-it verify</code>&#xFF01;</p>
       </div>
 
@@ -203,17 +203,17 @@
         <h2>&#x6487;&#x6B65;</h2>
         <ul>
           <li>&#x53EA;&#x7528;&#x4E00;&#x500B;&#x6307;&#x4EE4;&#x5C31;&#x65B0;&#x589E;&#x4E26;&#x5207;&#x63DB;&#x5230;&#x65B0;&#x7684; <n><span class="superscript">&#x5206;&#x652F;</span>branch</n></li>
-          <li><code>$ git checkout -b &lt;BRANCHNAME&gt;</code></li>
+          <li><code class="shell">git checkout -b &lt;BRANCHNAME&gt;</code></li>
           <li>&#x65B0;&#x589E; <n><span class="superscript">&#x5206;&#x652F;</span>branch</n></li>
-          <li><code>$ git branch &lt;BRANCHNAME&gt;</code></li>
+          <li><code class="shell">git branch &lt;BRANCHNAME&gt;</code></li>
           <li>&#x5207;&#x63DB;&#x5230;&#x53E6;&#x4E00;&#x500B; <n><span class="superscript">&#x5206;&#x652F;</span>branch</n></li>
-          <li><code>$ git checkout &lt;BRANCHNAME&gt;</code></li>
+          <li><code class="shell">git checkout &lt;BRANCHNAME&gt;</code></li>
           <li>&#x5217;&#x51FA;&#x6240;&#x6709;&#x7684; <n><span class="superscript">&#x5206;&#x652F;</span>branches</n></li>
-          <li><code>$ git branch</code></li>
+          <li><code class="shell">git branch</code></li>
           <li>&#x91CD;&#x65B0;&#x547D;&#x540D;&#x76EE;&#x524D;&#x6240;&#x5728;&#x7684; <n><span class="superscript">&#x5206;&#x652F;</span>branch</n></li>
-          <li><code>$ git branch -m &lt;NEWBRANCHNAME&gt;</code></li>
+          <li><code class="shell">git branch -m &lt;NEWBRANCHNAME&gt;</code></li>
           <li>&#x770B;&#x76EE;&#x524D;&#x6B63;&#x5728;&#x54EA;&#x500B; <n><span class="superscript">&#x5206;&#x652F;</span>branch</n></li>
-          <li><code>$ git status</code></li>
+          <li><code class="shell">git status</code></li>
         </ul>
       </div>
 

--- a/challenges-zhtw/commit_to_it.html
+++ b/challenges-zhtw/commit_to_it.html
@@ -133,15 +133,15 @@
       <h2>&#x6B65;&#x9A5F;&#xFF1A;<n><span class="superscript">&#x73FE;&#x6CC1;</span>status</n>&#x3001;<v><span class="superscript">&#x65B0;&#x589E;</span>add</v> &#x53CA; <v><span class="superscript">&#x63D0;&#x4EA4;</span>commit</v> &#x4FEE;&#x6539;</h2>
       <p>&#x63A5;&#x8457;&#x6AA2;&#x67E5;&#x4F60;&#x7684; <n><span class="superscript">&#x7A0B;&#x5F0F;&#x5EAB;</span>repository</n> &#x7684; <strong><n><span class="superscript">&#x73FE;&#x6CC1;</span>status</n></strong>&#xFF0C;&#x770B;&#x770B;&#x662F;&#x5426;&#x5728;&#x88E1;&#x982D;&#x6709;&#x4EFB;&#x4F55;&#x4FEE;&#x6539;&#x3002;&#x56DE;&#x5230;&#x4F60;&#x7684;&#x7D42;&#x7AEF;&#x6A5F;&#xFF0C;&#x61C9;&#x8A72;&#x9084;&#x5728;&#x4F60;&#x525B;&#x525B;&#x6240;&#x5EFA;&#x7ACB;&#x7684; &apos;hello-world&apos; &#x8CC7;&#x6599;&#x593E;&#x88E1;&#x982D;&#xFF0C;&#x76F4;&#x63A5;&#x7528;&#x9019;&#x500B;&#x6307;&#x4EE4;&#x67E5;&#x770B;&#x72C0;&#x614B;&#xFF1A;</p>
 
-      <p><code>$ git status</code></p>
+      <p><code class="shell">git status</code></p>
 
       <p>&#x63A5;&#x8457;&#x5C07;&#x525B;&#x525B;&#x5EFA;&#x7ACB;&#x6A94;&#x6848;&#xFF0C;<v><span class="superscript">&#x65B0;&#x589E;</span>add</v> &#x9032;&#x4F60;&#x60F3; <strong><v><span class="superscript">&#x63D0;&#x4EA4;</span>commit</v></strong>&#xFF08;&#x6216;&#x5132;&#x5B58;&#xFF09;&#x7684;&#x4FEE;&#x6539;&#x3002;
 
-      </p><p><code>$ git add readme.txt</code></p>
+      </p><p><code class="shell">git add readme.txt</code></p>
 
       <p>&#x6700;&#x5F8C;&#xFF0C;&#x5C07;&#x90A3;&#x4E9B;&#x4FEE;&#x6539; <v><span class="superscript">&#x63D0;&#x4EA4;</span><strong>commit</strong></v> &#x5230; <n><span class="superscript">&#x7A0B;&#x5F0F;&#x5EAB;</span>repository</n> &#x7684;&#x6B77;&#x53F2;&#x7D00;&#x9304;&#x7576;&#x4E2D;&#xFF0C;&#x4E26;&#x96A8;&#x9644;&#x4E0A;&#x4E00;&#x500B;&#x7C21;&#x77ED;&#x7684;&#x7570;&#x52D5;&#x8AAA;&#x660E;&#x3002;</p>
 
-      <p><code>$ git commit -m &quot;&lt;your commit message&gt;&quot;</code></p>
+      <p><code class="shell">git commit -m &quot;&lt;your commit message&gt;&quot;</code></p>
 
       <h2>&#x6B65;&#x9A5F;&#xFF1A;&#x9032;&#x884C;&#x66F4;&#x591A;&#x4FEE;&#x6539;</h2>
 
@@ -149,7 +149,7 @@
 
       <p>&#x5728;&#x7D42;&#x7AEF;&#x6A5F;&#x88E1;&#x4F60;&#x53EF;&#x4EE5;&#x67E5;&#x770B;&#x6709;&#x90A3;&#x4E9B; <strong><n><span class="superscript">&#x5DEE;&#x7570;</span>diff</n></strong> &#x5B58;&#x5728;&#x65BC;&#x73FE;&#x5728;&#x7684;&#x6A94;&#x6848;&#x4EE5;&#x53CA;&#x4E0A;&#x6B21;&#x4F60;&#x6240; <v><span class="superscript">&#x63D0;&#x4EA4;</span>commit</v> &#x7684;&#x6A94;&#x6848;&#x4E4B;&#x9593;&#x3002;</p>
 
-      <p><code>$ git diff</code></p>
+      <p><code class="shell">git diff</code></p>
 
       <p>&#x5229;&#x7528;&#x4F60;&#x525B;&#x525B;&#x6240;&#x5B78;&#x5230;&#x7684;&#x77E5;&#x8B58;&#xFF0C;<v><span class="superscript">&#x63D0;&#x4EA4;</span>commit</v> &#x9019;&#x500B;&#x6700;&#x65B0;&#x7684;&#x4FEE;&#x6539;&#x3002;</p>
 
@@ -167,15 +167,15 @@
         <h2>&#x6487;&#x6B65;</h2>
         <ul>
           <li><strong>&#x6AA2;&#x67E5; <n><span class="superscript">&#x7A0B;&#x5F0F;&#x5EAB;</span>repository</n> &#x4E2D;&#x7684;&#x4FEE;&#x6539; <n><span class="superscript">&#x73FE;&#x6CC1;</span>status</n></strong></li>
-          <li><code>$ git status</code></li>
+          <li><code class="shell">git status</code></li>
           <li><strong>&#x67E5;&#x770B;&#x5C0D;&#x6A94;&#x6848;&#x7684;&#x4FEE;&#x6539;</strong></li>
-          <li><code>$ git diff</code></li>
+          <li><code class="shell">git diff</code></li>
           <li><strong>&#x6E96;&#x5099; <v><span class="superscript">&#x63D0;&#x4EA4;</span>commit</v> &#x5C0D;&#x65BC;&#x4E00;&#x500B;&#x6A94;&#x6848;&#x7684;&#x4FEE;&#x6539;</strong></li>
-          <li><code>$ git add &lt;FILENAME&gt;</code></li>
+          <li><code class="shell">git add &lt;FILENAME&gt;</code></li>
           <li><strong>&#x6E96;&#x5099; <v><span class="superscript">&#x63D0;&#x4EA4;</span>commit</v> &#x5C0D;&#x65BC;&#x6240;&#x6709;&#x6A94;&#x6848;&#x7684;&#x4FEE;&#x6539;</strong></li>
-          <li><code>$ git add .</code></li>
+          <li><code class="shell">git add .</code></li>
           <li><strong><v><span class="superscript">&#x63D0;&#x4EA4;</span>commit</v>(&#x6216;&#x5132;&#x5B58;&#xFF09;&#x60A8;&#x6240;&#x6E96;&#x5099;&#x597D;&#x7684;&#x4FEE;&#x6539;&#x4E26;&#x9644;&#x4E0A;&#x4E00;&#x500B;&#x7C21;&#x77ED;&#x7684;&#x7570;&#x52D5;&#x8AAA;&#x660E;</strong></li>
-          <li><code>$ git commit -m &quot;&lt;your commit message&gt;&quot;</code></li>
+          <li><code class="shell">git commit -m &quot;&lt;your commit message&gt;&quot;</code></li>
         <ul>
       </ul></ul></div>
 

--- a/challenges-zhtw/forks_and_clones.html
+++ b/challenges-zhtw/forks_and_clones.html
@@ -141,14 +141,14 @@
       <h2>&#x6B65;&#x9A5F;&#xFF1A;&#x5728;&#x96FB;&#x8166;&#x4E0A; <v><span class="superscript">&#x4E0B;&#x8F09;</span>Clone</v> <n><span class="superscript">&#x8907;&#x672C;</span>Fork</n></h2>
       <p>&#x73FE;&#x5728;&#xFF0C;&#x5728;&#x7D42;&#x7AEF;&#x6A5F; <v><span class="superscript">&#x4E0B;&#x8F09;</span>clone</v> <n><span class="superscript">&#x7A0B;&#x5F0F;&#x5EAB;</span>repository</n> &#x5230;&#x4F60;&#x7684;&#x96FB;&#x8166;&#x4E0A;&#xFF0C;&#x4ED6;&#x6703;&#x81EA;&#x52D5;&#x66FF; <n><span class="superscript">&#x7A0B;&#x5F0F;&#x5EAB;</span>repository</n> &#x5EFA;&#x7ACB;&#x4E00;&#x500B;&#x65B0;&#x7684;&#x8CC7;&#x6599;&#x593E;&#xFF0C;&#x6240;&#x4EE5;&#x4F60;&#x4E0D;&#x9700;&#x8981;&#x81EA;&#x5DF1;&#x5EFA;&#x7ACB;&#x4E00;&#x500B;&#x3002;&#x4F46;&#x8ACB;&#x6CE8;&#x610F;&#x4E0D;&#x8981;&#x5728;&#x53E6;&#x4E00;&#x500B; Git <n><span class="superscript">&#x7A0B;&#x5F0F;&#x5EAB;</span>repository</n> &#x8CC7;&#x6599;&#x593E;&#x4E2D; <v><span class="superscript">&#x4E0B;&#x8F09;</span>clone</v>&#xFF01;&#x6240;&#x4EE5;&#xFF0C;&#x5982;&#x679C;&#x4F60;&#x9084;&#x5728;&#x5148;&#x524D;&#x6311;&#x6230;&#x6240;&#x4F7F;&#x7528;&#x7684; &apos;hello-world&apos; <n><span class="superscript">&#x7A0B;&#x5F0F;&#x5EAB;</span>repository</n> &#x4E2D;&#xFF0C;&#x8ACB;&#x5148;&#x96E2;&#x958B;&#x90A3;&#x500B;&#x8CC7;&#x6599;&#x593E;&#x3002;&#x4F60;&#x53EF;&#x4EE5;&#x900F;&#x904E;&#x5207;&#x63DB;&#x8CC7;&#x6599;&#x593E;&#x6307;&#x4EE4;&#x4EE5;&#x53CA;&#x5169;&#x500B;&#x9EDE;&#x4F86;&#x79FB;&#x52D5;&#x5230;&#x8CC7;&#x6599;&#x593E;&#x7684;&#x4E0A;&#x4E00;&#x5C64;&#xFF1A;
 
-      </p><p><code>$ cd ..</code></p>
+      </p><p><code class="shell">cd ..</code></p>
 
       &#x7136;&#x5F8C; <v><span class="superscript">&#x4E0B;&#x8F09;</span>clone</v>&#xFF1A;
 
-      <p><code>$ git clone &lt;URLFROMGITHUB&gt;</code></p>
+      <p><code class="shell">git clone &lt;URLFROMGITHUB&gt;</code></p>
 
       <p>&#x5207;&#x63DB;&#x5230;&#x525B;&#x525B;&#x5EFA;&#x7ACB;&#x7684; <n><span class="superscript">&#x8907;&#x672C;</span>fork</n> &#x8CC7;&#x6599;&#x593E;&#xFF08;&#x5728;&#x9019;&#x500B;&#x4F8B;&#x5B50;&#x4E2D;&#x53EB;&#x505A; &apos;patchwork&apos;&#xFF09;&#xFF1A;</p>
-      <p><code>$ cd patchwork</code></p>
+      <p><code class="shell">cd patchwork</code></p>
 
       <p>&#x73FE;&#x5728;&#x4F60;&#x5DF2;&#x7D93;&#x5728;&#x96FB;&#x8166;&#x4E0A;&#x5F97;&#x5230;&#x4E86;&#x4E00;&#x4EFD; <n><span class="superscript">&#x7A0B;&#x5F0F;&#x5EAB;</span>repository</n> &#x7684;&#x526F;&#x672C;&#xFF0C;&#x4E26;&#x4E14;&#x88AB;&#x81EA;&#x52D5;&#x9023;&#x63A5;&#x5230;&#x4F60; GitHub &#x5E33;&#x865F;&#x4E0B;&#x7684; <n><span class="superscript">&#x9060;&#x7AEF;</span>remote</n> <n><span class="superscript">&#x7A0B;&#x5F0F;&#x5EAB;</span>repository</n>&#xFF08;&#x4F60;&#x7684; <n><span class="superscript">&#x8907;&#x672C;</span>fork</n> &#x526F;&#x672C;&#xFF09;&#x3002;</p>
 
@@ -158,7 +158,7 @@
 
       <p>&#x4F60;&#x53EF;&#x4EE5;&#x96A8;&#x610F;&#x66FF;&#x9019;&#x500B; <n><span class="superscript">&#x9060;&#x7AEF;</span>remote</n> &#x9023;&#x7D50;&#x547D;&#x540D;&#xFF0C;&#x4F46;&#x5927;&#x5BB6;&#x901A;&#x5E38;&#x7528; &apos;upstream&apos;&#xFF0C;&#x8B93;&#x6211;&#x5011;&#x4E5F;&#x7528;&#x9019;&#x500B;&#x540D;&#x5B57;&#xFF1A;</p>
 
-      <p><code>$ git remote add upstream https://github.com/jlord/patchwork.git</code></p>
+      <p><code class="shell">git remote add upstream https://github.com/jlord/patchwork.git</code></p>
 
 <div class="verify">
   <button class="white" id="verify-challenge">VERIFY</button>
@@ -174,9 +174,9 @@
         <h2>&#x6487;&#x6B65;</h2>
         <ul>
           <li><strong>&#x65B0;&#x589E; <n><span class="superscript">&#x9060;&#x7AEF;</span>remote</n> &#x9023;&#x7D50;</strong></li>
-          <li><code>$ git remote add &lt;REMOTENAME&gt; &lt;URL&gt;</code></li>
+          <li><code class="shell">git remote add &lt;REMOTENAME&gt; &lt;URL&gt;</code></li>
           <li><strong>&#x6AA2;&#x8996; <n><span class="superscript">&#x9060;&#x7AEF;</span>remote</n> &#x9023;&#x7D50;</strong></li>
-          <li><code>$ git remote -v</code></li>
+          <li><code class="shell">git remote -v</code></li>
         </ul>
       </div>
 

--- a/challenges-zhtw/get_git.html
+++ b/challenges-zhtw/get_git.html
@@ -150,7 +150,7 @@
 
       <p>&#x5B89;&#x88DD;&#x597D; Git &#x5F8C;&#xFF0C;&#x6253;&#x958B; <strong>&#x7D42;&#x7AEF;&#x6A5F;</strong>&#xFF08;&#x6216; Bash&#x3001;Shell&#x3001;Prompt&#x3001;&#x547D;&#x4EE4;&#x63D0;&#x793A;&#x5B57;&#x5143;&#x4ECB;&#x9762;&#xFF09;&#xFF0C;&#x4E26;&#x8F38;&#x5165;&#x4EE5;&#x4E0B;&#x6307;&#x4EE4;&#x4F86;&#x78BA;&#x8A8D;&#x4F60;&#x6709;&#x9806;&#x5229;&#x5B89;&#x88DD;&#x597D; Git&#xFF1A;</p>
 
-      <p><code>$ git --version </code></p>
+      <p><code class="shell">git --version </code></p>
 
       <p>&#x5982;&#x679C;&#x6709;&#x5B89;&#x88DD;&#x6210;&#x529F;&#xFF0C;&#x9019;&#x500B;&#x6307;&#x4EE4;&#x5C07;&#x6703;&#x544A;&#x8A34;&#x4F60;&#xFF0C;&#x4F60;&#x6240;&#x5B89;&#x88DD;&#x7684;&#x7248;&#x672C;&#x865F;&#x78BC;&#xFF0C;&#x5982;&#xFF1A;</p>
 
@@ -161,9 +161,9 @@
       <p>&#x63A5;&#x4E0B;&#x4F86;&#xFF0C;&#x8B93; Git &#x77E5;&#x9053;&#x9019;&#x53F0;&#x96FB;&#x8166;&#x6240;&#x505A;&#x7684;&#x4FEE;&#x6539;&#x8A72;&#x9023;&#x7D50;&#x5230;&#x4EC0;&#x9EBC;&#x4F7F;&#x7528;&#x8005;&#xFF1A;</p>
 
       <p>&#x8A2D;&#x5B9A;&#x4F60;&#x7684;&#x540D;&#x5B57;&#xFF1A;</p>
-      <p><code>$ git config --global user.name &quot;&lt;Your Name&gt;&quot;</code></p>
+      <p><code class="shell">git config --global user.name &quot;&lt;Your Name&gt;&quot;</code></p>
       <p>&#x8A2D;&#x5B9A;&#x4F60;&#x7684;&#x96FB;&#x5B50;&#x4FE1;&#x7BB1;&#xFF1A;</p>
-      <p><code>$ git config --global user.email &quot;&lt;youremail@example.com&gt;&quot;</code></p>
+      <p><code class="shell">git config --global user.email &quot;&lt;youremail@example.com&gt;&quot;</code></p>
 
 <div class="verify">
   <button class="white" id="verify-challenge">VERIFY</button>

--- a/challenges-zhtw/githubbin.html
+++ b/challenges-zhtw/githubbin.html
@@ -140,7 +140,7 @@
 
       <p>&#x544A;&#x8A34; Git &#x4F60;&#x7684; GitHub &#x5E33;&#x865F;&#xFF1A;</p>
 
-      <code>$ git config --global user.username &lt;USerNamE&gt;</code>
+      <code class="shell">git config --global user.username &lt;USerNamE&gt;</code>
       <br><br>
 
 <div class="verify">
@@ -156,7 +156,7 @@
         <h4>GitHub &amp; Git config usernames do not match</h4>
         <p>&#x5E38;&#x898B;&#x7684;&#x932F;&#x8AA4;&#x662F; GitHub &#x5E33;&#x865F;&#x8DDF; <code>git config</code> &#x8A2D;&#x5B9A;&#x7684;&#x5E33;&#x865F;&#x6C92;&#x6709;&#x4E00;&#x81F4;&#x3002;&#x8B6C;&#x5982; &apos;jlord&apos; &#x8DDF; &apos;JLord&apos; &#x662F;&#x4E0D;&#x4E00;&#x6A23;&#x7684;&#x54E6;&#x3002;</p>
         <p>&#x8981;&#x4FEE;&#x6539; Git &#x8A2D;&#x5B9A;&#x7684;&#x5E33;&#x865F;&#xFF0C;&#x53EA;&#x8981;&#x518D;&#x7528;&#x4E00;&#x6B21;&#x4E0A;&#x9762;&#x6559;&#x7684;&#x6307;&#x4EE4;&#xFF0C;&#x5927;&#x5C0F;&#x5BEB;&#x6253;&#x5C0D;&#x5C31;&#x53EF;&#x4EE5;&#x4E86;&#xFF1A;</p>
-        <p><code>$ git config --global user.username &lt;USerNamE&gt;</code></p>
+        <p><code class="shell">git config --global user.username &lt;USerNamE&gt;</code></p>
         <p>&#x66F4;&#x65B0;&#x5B8C;&#x4E4B;&#x5F8C;&#xFF0C;&#x518D;&#x6AA2;&#x67E5;&#x4E00;&#x6B21;&#x770B;&#x770B;&#x5427;&#xFF01;</p>
       </div>
 

--- a/challenges-zhtw/merge_tada.html
+++ b/challenges-zhtw/merge_tada.html
@@ -130,24 +130,24 @@
 
       <p>&#x9996;&#x5148;&#xFF0C;&#x5207;&#x63DB;&#x5230;&#x60F3;&#x8981; <v><span class="superscript">&#x5408;&#x4F75;</span>merge</v> <strong>&#x9032;&#x53BB;</strong>&#x7684; <n><span class="superscript">&#x5206;&#x652F;</span>branch</n>&#xFF0C;&#x4E5F;&#x5C31;&#x662F; &apos;gh-pages&apos;&#x3002;</p>
 
-      <p><code>$ git checkout gh-pages</code></p>
+      <p><code class="shell">git checkout gh-pages</code></p>
 
       <p>&#x544A;&#x8A34; Git &#x4F60;&#x60F3;&#x8981; <v><span class="superscript">&#x5408;&#x4F75;</span>merge</v> &#x90A3;&#x500B; <n><span class="superscript">&#x5206;&#x652F;</span>branch</n> <strong>&#x9032;&#x4F86;</strong>&#xFF0C;&#x4E5F;&#x5C31;&#x662F;&#x4F60;&#x7684; <n><span class="superscript">&#x529F;&#x80FD;</span>feature</n> <n><span class="superscript">&#x5206;&#x652F;</span>branch</n>&#xFF0C;&#x540D;&#x5B57;&#x662F; &apos;add-username&apos;&#x3002;</p>
 
-      <p><code>$ git merge &lt;BRANCHNAME&gt;</code></p>
+      <p><code class="shell">git merge &lt;BRANCHNAME&gt;</code></p>
 
       <p>&#x6574;&#x7406;&#x4E00;&#x4E0B;&#x5427;&#xFF0C;&#x73FE;&#x5728;&#x628A;&#x525B;&#x525B;&#x5DF2;&#x7D93; <v><span class="superscript">&#x5408;&#x4F75;</span>merged</v> &#x7684; <n><span class="superscript">&#x529F;&#x80FD;</span>feature</n> <n><span class="superscript">&#x5206;&#x652F;</span>branch</n> &#x522A;&#x6389;&#x3002;</p>
-      <p><code>$ git branch -d &lt;BRANCHNAME&gt;</code></p>
+      <p><code class="shell">git branch -d &lt;BRANCHNAME&gt;</code></p>
 
       <p>&#x4E5F;&#x53EF;&#x4EE5;&#x628A; <n><span class="superscript">&#x5206;&#x652F;</span>branch</n> &#x5F9E; GitHub &#x4E0A;&#x7684; <adj><span class="superscript">&#x8907;&#x672C;&#x7684;</span>forked</adj> <n><span class="superscript">&#x7A0B;&#x5F0F;&#x5EAB;</span>repository</n> &#x4E2D;&#x522A;&#x9664;&#x54E6;&#xFF1A;</p>
-      <p><code>$ git push &lt;REMOTENAME&gt; --delete &lt;BRANCHNAME&gt;</code></p>
+      <p><code class="shell">git push &lt;REMOTENAME&gt; --delete &lt;BRANCHNAME&gt;</code></p>
 
       <h2>&#x6B65;&#x9A5F;&#xFF1A; &#x5F9E; <n><span class="superscript">&#x4E0A;&#x6E38;</span>Upstream</n> <v><span class="superscript">&#x6536;&#x53D6;</span>Pull</v></h2>
       <p>&#x6700;&#x5F8C;&#x4E00;&#x6B65;&#xFF0C;&#x4F46;&#x4E5F;&#x662F;&#x5F88;&#x91CD;&#x8981;&#x7684;&#x4E00;&#x6B65;&#xFF0C;&#x82E5;&#x5F9E;&#x539F;&#x5C08;&#x6848;&#xFF08;&#x73FE;&#x5728;&#x9996;&#x9801;&#x5DF2;&#x7D93;&#x6709;&#x4F60;&#x7684;&#x540D;&#x5B57;&#x4E86;&#x54E6;&#xFF09;<v><span class="superscript">&#x6536;&#x53D6;</span>pull</v> &#x56DE;&#x4F86;&#xFF0C;&#x4F60;&#x4E5F;&#x6703;&#x6709;&#x4E00;&#x500B;&#x76F8;&#x540C;&#x7684;&#x7DB2;&#x9801;&#xFF0C;&#x4F4D;&#x7F6E;&#x5728; yourusername.github.io/patchwork&#x3002;</p>
 
       <p>&#x5F9E;&#x539F;&#x672C;&#x7684; <n><span class="superscript">&#x4E0A;&#x6E38;</span>upstream</n> <v><span class="superscript">&#x6536;&#x53D6;</span>pull</v> &#x56DE;&#x4F86;&#xFF1A;</p>
 
-      <p><code>$ git pull upstream gh-pages</code></p>
+      <p><code class="shell">git pull upstream gh-pages</code></p>
 
       <h2>&#x606D;&#x559C;&#x606D;&#x559C;&#xFF01;</h2>
       <p>&#x4F60;&#x5728;&#x672C;&#x6A5F;&#x5EFA;&#x7ACB;&#x4E86; <n><span class="superscript">&#x7A0B;&#x5F0F;&#x5EAB;</span>repositories</n>&#xFF0C;&#x8207;&#x4E00;&#x540D; <n><span class="superscript">&#x5925;&#x4F34;</span>collaborator</n> &#x5354;&#x4F5C;&#x3001;<v><span class="superscript">&#x63A8;&#x9001;</span>push</v>&#x3001;<v><span class="superscript">&#x6536;&#x53D6;</span>pull</v>&#xFF0C;&#x52A0;&#x5165;&#x4E86;&#x767E;&#x842C;&#x958B;&#x767C;&#x8005;&#x6240;&#x8655;&#x7684;&#x958B;&#x6E90;&#x4E16;&#x754C;&#xFF0C;&#x662F;&#x4F60;&#xFF0C;&#x8C50;&#x5BCC;&#x4E86;&#x958B;&#x6E90;&#x4E16;&#x754C;&#xFF01;</p>
@@ -167,15 +167,15 @@
         <h2>&#x6487;&#x6B65;</h2>
         <ul>
           <li><strong><v><span class="superscript">&#x5408;&#x4F75;</span>Merge</v> <n><span class="superscript">&#x5206;&#x652F;</span>branch</n> &#x5230;&#x76EE;&#x524D;&#x7684; <n><span class="superscript">&#x5206;&#x652F;</span>branch</n></strong></li>
-          <code>$ git merge &lt;BRANCHNAME&gt;</code>
+          <code class="shell">git merge &lt;BRANCHNAME&gt;</code>
           <li><strong>&#x5207;&#x63DB;&#x6B63;&#x5728;&#x5DE5;&#x4F5C;&#x7684; <n><span class="superscript">&#x5206;&#x652F;</span>branch</n></strong></li>
-          <code>$ git checkout &lt;BRANCHNAME&gt;</code>
+          <code class="shell">git checkout &lt;BRANCHNAME&gt;</code>
           <li><strong>&#x522A;&#x9664;&#x672C;&#x6A5F;&#x7684; <n><span class="superscript">&#x5206;&#x652F;</span>branch</n></strong></li>
-          <code>$ git branch -d &lt;BRANCHNAME&gt;</code>
+          <code class="shell">git branch -d &lt;BRANCHNAME&gt;</code>
           <li><strong>&#x522A;&#x9664; <n><span class="superscript">&#x9060;&#x7AEF;</span>remote</n> <n><span class="superscript">&#x5206;&#x652F;</span>branch</n></strong></li>
-          <code>$ git push &lt;REMOTENAME&gt; --delete &lt;BRANCHNAME&gt;</code>
+          <code class="shell">git push &lt;REMOTENAME&gt; --delete &lt;BRANCHNAME&gt;</code>
           <li><strong>&#x5F9E; <n><span class="superscript">&#x9060;&#x7AEF;</span>remote</n> <n><span class="superscript">&#x5206;&#x652F;</span>branch</n> <v><span class="superscript">&#x6536;&#x53D6;</span>Pull</v></strong></li>
-          <code>$ git pull &lt;REMOTENAME&gt; &lt;BRANCHNAME&gt;</code>
+          <code class="shell">git pull &lt;REMOTENAME&gt; &lt;BRANCHNAME&gt;</code>
         </ul>
       </div>
 

--- a/challenges-zhtw/pull_never_out_of_date.html
+++ b/challenges-zhtw/pull_never_out_of_date.html
@@ -133,7 +133,7 @@
 
       <p>&#x628A; GitHub &#x4E0A; &apos;origin&apos; <n><span class="superscript">&#x9060;&#x7AEF;</span>remote</n> &#x7684;&#x66F4;&#x65B0; <v><span class="superscript">&#x6536;&#x53D6;</span>pull</v> &#x5230;&#x4F60;&#x7684;&#x96FB;&#x8166;&#x4E0A;&#xFF0C;&#x4F86;&#x770B; Reporobot &#x662F;&#x5426;&#x6709;&#x5728; &apos;add-&apos; <n><span class="superscript">&#x5206;&#x652F;</span>branch</n> &#x505A;&#x4E86;&#x4EFB;&#x4F55;&#x4FEE;&#x6539;&#xFF1A;</p>
 
-      <p><code>$ git pull &lt;REMOTENAME&gt; &lt;BRANCHNAME&gt;</code></p>
+      <p><code class="shell">git pull &lt;REMOTENAME&gt; &lt;BRANCHNAME&gt;</code></p>
 
       <p>&#x5982;&#x679C;&#x6C92;&#x6709;&#x4EFB;&#x4F55;&#x4FEE;&#x6539;&#xFF0C;Git &#x6703;&#x544A;&#x8A34;&#x4F60; &apos;Already up-to-date&apos;&#x3002;&#x82E5;&#x6709;&#x4FEE;&#x6539;&#x7684;&#x8A71;&#xFF0C;Git &#x6703;&#x628A;&#x90A3;&#x4E9B;&#x4FEE;&#x6539; <v><span class="superscript">&#x5408;&#x4F75;</span>merge</v> &#x5230;&#x96FB;&#x8166;&#x88E1;&#x54E6;&#x3002;</p>
 
@@ -153,11 +153,11 @@
         <h2>&#x6487;&#x6B65;</h2>
           <ul>
           <li><strong>&#x6AA2;&#x67E5; Git &#x72C0;&#x614B;</strong></li>
-          <code>$ git status</code>
+          <code class="shell">git status</code>
           <li><strong>&#x5F9E;&#x9060;&#x7AEF;&#x5206;&#x652F; <v><span class="superscript">&#x6536;&#x53D6;</span>pull</v> &#x66F4;&#x65B0;&#x56DE;&#x4F86;</strong></li>
-          <code>$ git pull <remotename> <remotebranch></remotebranch></remotename></code>
+          <code class="shell">git pull <remotename> <remotebranch></remotebranch></remotename></code>
           <li><strong>&#x5728;&#x6536;&#x53D6;&#x66F4;&#x65B0;&#x524D;&#x5148;&#x6AA2;&#x67E5; <n><span class="superscript">&#x9060;&#x7AEF;</span>remote</n> &#x662F;&#x5426;&#x6709;&#x8B8A;&#x52D5;</strong></li>
-          <code>$ git fetch --dry-run</code>
+          <code class="shell">git fetch --dry-run</code>
         </ul>
       </div>
 

--- a/challenges-zhtw/remote_control.html
+++ b/challenges-zhtw/remote_control.html
@@ -163,7 +163,7 @@
 
       <p>&#x56DE;&#x5230;&#x7D42;&#x7AEF;&#x6A5F;&#xFF0C;&#x5728;&#x6211;&#x5011;&#x525B;&#x525B;&#x521D;&#x59CB;&#x5316;&#x904E; Git &#x7684; &apos;hello-world&apos; &#x7684;&#x8CC7;&#x6599;&#x593E;&#x88E1;&#x982D;&#xFF0C;&#x6211;&#x5011;&#x9700;&#x8981;&#x544A;&#x8A34; Git &#x9019;&#x500B; <n><span class="superscript">&#x9060;&#x7AEF;</span>remote</n> &#x7684;&#x4F4D;&#x5740;&#x3002;&#x540C;&#x4E00;&#x500B; Git &#x5C08;&#x6848;&#x4E2D;&#xFF0C;&#x53EF;&#x4EE5;&#x6709;&#x5F88;&#x591A;&#x4E0D;&#x540C;&#x7684; <n><span class="superscript">&#x9060;&#x7AEF;</span>remote</n>&#xFF0C;&#x6240;&#x4EE5;&#x6BCF;&#x4E00;&#x500B; <n><span class="superscript">&#x9060;&#x7AEF;</span>remote</n> &#x90FD;&#x9700;&#x8981;&#x4E00;&#x500B;&#x540D;&#x5B57;&#x3002;&#x800C;&#x6700;&#x4E3B;&#x8981;&#x3001;&#x539F;&#x59CB;&#x7684;&#x90A3;&#x4E00;&#x500B;&#xFF0C;&#x901A;&#x5E38;&#x90FD;&#x662F;&#x53EB;&#x505A; <code>origin</code>&#x3002;</p>
 
-      <code>$ git remote add origin &lt;URLFROMGITHUB&gt;</code>
+      <code class="shell">git remote add origin &lt;URLFROMGITHUB&gt;</code>
 
       <p>&#x4F60;&#x96FB;&#x8166;&#x4E0A;&#x7684; <n><span class="superscript">&#x7A0B;&#x5F0F;&#x5EAB;</span>repository</n> &#x73FE;&#x5728;&#x77E5;&#x9053;&#x4E86;&#x5C08;&#x6848;&#x6709;&#x4E00;&#x500B;&#x5728; GitHub &#x4E0A;&#x7684; <strong><n><span class="superscript">&#x9060;&#x7AEF;</span>remote</n></strong>&#xFF0C;&#x53EB;&#x505A; &apos;origin&apos;&#x3002;&#x4F60;&#x53EF;&#x4EE5;&#x60F3;&#x50CF;&#x9019;&#x5C31;&#x597D;&#x50CF;&#x662F;&#x628A;&#x4E00;&#x500B;&#x96FB;&#x8A71;&#x865F;&#x78BC;&#x914D;&#x4E0A;&#x4E00;&#x500B;&#x540D;&#x5B57;&#x4E00;&#x6A23;&#xFF0C;&#x9019;&#x6A23;&#x7576;&#x4F60;&#x8981;&#x6253;&#x96FB;&#x8A71;&#x7684;&#x6642;&#x5019;&#xFF0C;&#x5C31;&#x4E0D;&#x7528;&#x8A18;&#x5F97;&#x865F;&#x78BC;&#x4E86;&#x3002;</p>
 
@@ -171,7 +171,7 @@
         <p><strong>&#x5099;&#x8A3B;&#xFF1A;</strong></p>
         <p>&#x5982;&#x679C;&#x4F60;&#x6709;&#x5B89;&#x88DD; <strong>GitHub for Windows</strong>&#xFF0C;Git &#x521D;&#x59CB;&#x5316;&#x7684;&#x6642;&#x5019;&#x5C31;&#x6703;&#x76F4;&#x63A5;&#x8A2D;&#x5B9A;&#x4E86;&#x4E00;&#x500B;&#x53EB;&#x505A; &apos;origin&apos; &#x7684; <n><span class="superscript">&#x9060;&#x7AEF;</span>remote</n>&#xFF0C;&#x6240;&#x4EE5;&#x4F60;&#x4E0D;&#x9700;&#x8981;&#x65B0;&#x589E;&#xFF0C;&#x53EA;&#x8981;&#x8A2D;&#x5B9A;&#x9019;&#x500B; &apos;origin&apos; <n><span class="superscript">&#x9060;&#x7AEF;</span>remote</n> &#x7684;&#x4F4D;&#x5740;&#x5C31;&#x597D;&#x4E86;&#xFF1A;</p>
 
-        <code>$ git remote set-url origin &lt;URLFROMGITHUB&gt;</code>
+        <code class="shell">git remote set-url origin &lt;URLFROMGITHUB&gt;</code>
       </blockquote>
 
       <h2>&#x6B65;&#x9A5F;&#xFF1A;&#x628A;&#x4F60;&#x7684;&#x4FEE;&#x6539; <v><span class="superscript">&#x63A8;&#x9001;</span>Push</v> &#x5230; <n><span class="superscript">&#x9060;&#x7AEF;</span>remote</n></h2>
@@ -182,7 +182,7 @@
 
       <p>&#x4E5F;&#x5C31;&#x662F;&#x8AAA;&#xFF0C;&#x6211;&#x5011;&#x73FE;&#x5728;&#x60F3;&#x8981;&#x628A; &apos;master&apos; <n><span class="superscript">&#x5206;&#x652F;</span>branch</n> &#x7684;&#x7A0B;&#x5F0F;&#x50B3;&#x9001;&#x5230;&#x5148;&#x524D;&#x65B0;&#x589E;&#x7684; &apos;origin&apos; <n><span class="superscript">&#x9060;&#x7AEF;</span>remote</n>&#x3002;</p>
 
-      <code>$ git push origin master</code>
+      <code class="shell">git push origin master</code>
 
       <p>&#x5B8C;&#x6210;&#x4E4B;&#x5F8C;&#xFF0C;&#x4F60;&#x73FE;&#x5728;&#x5C31;&#x53EF;&#x4EE5;&#x56DE;&#x5230; GitHub &#x7684; <n><span class="superscript">&#x7A0B;&#x5F0F;&#x5EAB;</span>repository</n> &#x9801;&#x9762;&#xFF0C;&#x91CD;&#x65B0;&#x6574;&#x7406;&#x3002;&#x54C7;&#x54C7;&#x54C7;&#xFF01;&#x7A0B;&#x5F0F;&#x662F;&#x4E0D;&#x662F;&#x90FD;&#x540C;&#x6B65;&#x4E86;&#x5462;&#xFF1F;&#x606D;&#x559C;&#x4F60;&#x5EFA;&#x7ACB;&#x4E86;&#x7B2C;&#x4E00;&#x500B;&#x516C;&#x958B;&#x7684; <n><span class="superscript">&#x7A0B;&#x5F0F;&#x5EAB;</span>repository</n>&#xFF01;</p>
 
@@ -200,15 +200,15 @@
         <h2>&#x6487;&#x6B65;</h2>
         <ul>
           <li><strong>&#x65B0;&#x589E; <n><span class="superscript">&#x9060;&#x7AEF;</span>remote</n> &#x9023;&#x7D50;</strong></li>
-          <code>$ git remote add &lt;REMOTENAME&gt; <url></url></code>
+          <code class="shell">git remote add &lt;REMOTENAME&gt; <url></url></code>
           <li><strong>&#x5E6B;&#x4E00;&#x500B; <n><span class="superscript">&#x9060;&#x7AEF;</span>remote</n> &#x8A2D;&#x5B9A;&#x4F4D;&#x5740;</strong></li>
-          <code>$ git remote set-url &lt;REMOTENAME&gt; <url></url></code>
+          <code class="shell">git remote set-url &lt;REMOTENAME&gt; <url></url></code>
           <li><strong><v><span class="superscript">&#x6536;&#x53D6;</span>Pull</v> <n><span class="superscript">&#x9060;&#x7AEF;</span>remote</n> &#x7684;&#x7A0B;&#x5F0F;</strong></li>
-          <code>$ git pull &lt;REMOTENAME&gt; &lt;BRANCHNAME&gt;</code>
+          <code class="shell">git pull &lt;REMOTENAME&gt; &lt;BRANCHNAME&gt;</code>
           <li><strong>&#x770B;&#x4F60;&#x6709;&#x54EA;&#x4E9B; <n><span class="superscript">&#x9060;&#x7AEF;</span>remote</n> &#x9023;&#x7D50;</strong></li>
-          <code>$ git remote -v</code>
+          <code class="shell">git remote -v</code>
           <li><strong><v><span class="superscript">&#x63A8;&#x9001;</span>Push</v> &#x96FB;&#x8166;&#x4E0A;&#x7684;&#x7A0B;&#x5F0F;&#x5230; <n><span class="superscript">&#x9060;&#x7AEF;</span>remote</n></strong></li>
-          <code>$ git push &lt;REMOTENAME&gt; <branch></branch></code>
+          <code class="shell">git push &lt;REMOTENAME&gt; <branch></branch></code>
         </ul>
       </div>
 

--- a/challenges-zhtw/repository.html
+++ b/challenges-zhtw/repository.html
@@ -148,13 +148,13 @@
       <p>&#x4F60;&#x53EF;&#x4EE5;&#x5C07;&#x4E0B;&#x5217;&#x6307;&#x4EE4;&#x4E00;&#x4E00;&#x8F38;&#x5165;&#x81F3;&#x7D42;&#x7AEF;&#x6A5F;&#x3002;</p>
 
       <p>&#x5EFA;&#x7ACB;&#x65B0;&#x8CC7;&#x6599;&#x593E;&#xFF1A;</p>
-      <code>$ mkdir hello-world</code>
+      <code class="shell">mkdir hello-world</code>
 
       <p>&#x9032;&#x5165;&#x9019;&#x500B;&#x8CC7;&#x6599;&#x593E;&#xFF1A;</p>
-      <code>$ cd hello-world</code>
+      <code class="shell">cd hello-world</code>
 
       <p>&#x628A;&#x9019;&#x500B;&#x8CC7;&#x6599;&#x593E;&#x8A2D;&#x5B9A;&#x6210;&#x4E00;&#x500B; Git &#x5C08;&#x6848;&#x8CC7;&#x6599;&#x593E;</p>
-      <code>$ git init</code>
+      <code class="shell">git init</code>
 
       <p>&#x5C31;&#x662F;&#x9019;&#x6A23;&#xFF01;&#x7D42;&#x7AEF;&#x6A5F;&#x6703;&#x56DE;&#x61C9;&#x4E26;&#x5207;&#x63DB;&#x5230;&#x4E0B;&#x4E00;&#x884C;&#x3002;&#x5982;&#x679C;&#x4F60;&#x60F3;&#x8981;&#x78BA;&#x8A8D;&#x6B64;&#x8CC7;&#x6599;&#x593E;&#x662F;&#x5426;&#x5DF2;&#x7D93;&#x662F;&#x500B; Git <n><span class="superscript">&#x7A0B;&#x5F0F;&#x5EAB;</span>repository</n>&#xFF0C;&#x8F38;&#x5165; <code>git status</code>&#xFF0C;&#x53EA;&#x8981;&#x4E0D;&#x662F;&#x986F;&#x793A; &apos;fatal: Not a git repository...&apos;&#xFF0C;&#x90A3;&#x5C31;&#x5C0D;&#x4E86;&#xFF01;</p>
 
@@ -172,13 +172,13 @@
         <h2>&#x6487;&#x6B65;</h2>
         <ul>
           <li><strong>&#x5EFA;&#x7ACB;&#x4E00;&#x500B;&#x65B0;&#x8CC7;&#x6599;&#x593E; (&#x6216;&#x7A31;&#x505A;&#x76EE;&#x9304;)</strong></li>
-          <code>$ mkdir &lt;FOLDERNAME&gt;</code>
+          <code class="shell">mkdir &lt;FOLDERNAME&gt;</code>
           <li><strong>&#x9032;&#x5165;&#x4E00;&#x500B;&#x8CC7;&#x6599;&#x593E; (&#x6216;&#x7A31;&#x505A;&#x5207;&#x63DB;&#x76EE;&#x9304;)</strong></li>
-          <code>$ cd &lt;FOLDERNAME&gt;</code>
+          <code class="shell">cd &lt;FOLDERNAME&gt;</code>
           <li><strong>&#x5217;&#x51FA;&#x8CC7;&#x6599;&#x593E;&#x5167;&#x5BB9;</strong></li>
-          <code>$ ls </code>
+          <code class="shell">ls </code>
           <li><strong>&#x70BA;&#x4E00;&#x500B;&#x8CC7;&#x6599;&#x593E;&#x52A0;&#x4E0A; Git &#x529F;&#x80FD;</strong></li>
-          <code>$ git init</code>
+          <code class="shell">git init</code>
         </ul>
       </div>
 

--- a/challenges/branches_arent_just_for_birds.html
+++ b/challenges/branches_arent_just_for_birds.html
@@ -156,14 +156,14 @@ GitHub Guide: <a href="http://guides.github.com/overviews/flow/" target="_blank"
 <p>Create a branch and name it "add-&#60;username&#62;", where 'username' is
   your username. For instance, "add-jlord". <strong>Branches are case-sensitive so name your branch exactly the way your GitHub name appears</strong>.</p>
 
-<p><code>$ git branch &#60;BRANCHNAME&#62;</code></p>
+<p><code class="shell">git branch &#60;BRANCHNAME&#62;</code></p>
 
 <p>Now you have a branch with a new name identical to 'gh-pages'.</p>
 
 <p>To go into that branch and work on it, similar to using <code>cd</code> to
   change directory in terminal, you <strong>checkout</strong> a branch. Go onto your new branch:</p>
 
-<p><code>$ git checkout &#60;BRANCHNAME&#62;</code></p>
+<p><code class="shell">git checkout &#60;BRANCHNAME&#62;</code></p>
 
 <h2>Step: Create a new file</h2>
 <p>Back to the text editor:</p>
@@ -179,13 +179,13 @@ GitHub Guide: <a href="http://guides.github.com/overviews/flow/" target="_blank"
 <h2>Step: Check-in</h2>
 <p>Go through the steps for checking in a project: </p>
 
-<p><code>$ git status</code></p>
-<p><code>$ git add &#60;FILENAME&#62;</code></p>
-<p><code>$ git commit -m "&#60;commit message&#62;"</code></p>
+<p><code class="shell">git status</code></p>
+<p><code class="shell">git add &#60;FILENAME&#62;</code></p>
+<p><code class="shell">git commit -m "&#60;commit message&#62;"</code></p>
 
 <p>Now push your update to your fork on GitHub:</p>
 
-<p><code>$ git push origin &#60;BRANCHNAME&#62;</code></p>
+<p><code class="shell">git push origin &#60;BRANCHNAME&#62;</code></p>
 
 <div class="verify">
   <button class="white" id='verify-challenge'>VERIFY</button>
@@ -202,12 +202,12 @@ GitHub Guide: <a href="http://guides.github.com/overviews/flow/" target="_blank"
 
   <h4>File NOT in contributors folder</h4>
   <p>The file you create should inside the existing 'contributors' folder in the Patchwork repository. If you put it somewhere else, simply use Finder or Windows Explorer to move your file into the folder. You can check <code>git status</code> again and you'll find it sees your changes. Stage and then commit "all" (-A) of these changes (additions and deletions) with the commands below.</p>
-  <p><code>$ git add -A</code></p>
-  <p><code>$ git commit -m "move file into contributors folder"</code></p>
+  <p><code class="shell">git add -A</code></p>
+  <p><code class="shell">git commit -m "move file into contributors folder"</code></p>
 
   <h4>Branch name expected: _____</h4>
   <p>The branch name should match your user name exactly. To change your branch name:</p>
-  <p><code>$ git branch -M &#60;NEWBRANCHNAME&#62;</code></p>
+  <p><code class="shell">git branch -M &#60;NEWBRANCHNAME&#62;</code></p>
   <p>When you've made your updates, verify again!</p>
 </div>
 
@@ -215,17 +215,17 @@ GitHub Guide: <a href="http://guides.github.com/overviews/flow/" target="_blank"
   <h2>Tips</h2>
   <ul>
     <li>You can create and switch to a branch in one line:</li>
-    <li><code>$ git checkout -b &#60;BRANCHNAME&#62;</code></li>
+    <li><code class="shell">git checkout -b &#60;BRANCHNAME&#62;</code></li>
     <li>Create a new branch:</li>
-    <li><code>$ git branch &#60;BRANCHNAME&#62;</code></li>
+    <li><code class="shell">git branch &#60;BRANCHNAME&#62;</code></li>
     <li>Move onto a branch:</li>
-    <li><code>$ git checkout &#60;BRANCHNAME&#62;</code></li>
+    <li><code class="shell">git checkout &#60;BRANCHNAME&#62;</code></li>
     <li>List the branches:</li>
-    <li><code>$ git branch</code></li>
+    <li><code class="shell">git branch</code></li>
     <li>Rename a branch you're currently on:</li>
-    <li><code>$ git branch -m &#60;NEWBRANCHNAME&#62;</code></li>
+    <li><code class="shell">git branch -m &#60;NEWBRANCHNAME&#62;</code></li>
     <li>Verify what branch you're working on</li>
-    <li><code>$ git status</code></li>
+    <li><code class="shell">git status</code></li>
   </ul>
 </div>
 

--- a/challenges/commit_to_it.html
+++ b/challenges/commit_to_it.html
@@ -137,16 +137,16 @@
   you should still be within the 'hello-world' you created. See if there
   are changes listed:</p>
 
-<p><code>$ git status</code></p>
+<p><code class="shell">git status</code></p>
 
 <p>Then <strong>add</strong> the file you just created to the files you'd
   like to <strong>commit</strong> (aka save) to change. </p>
 
-<p><code>$ git add readme.txt</code></p>
+<p><code class="shell">git add readme.txt</code></p>
 
 <p>Finally, <strong>commit</strong> those changes to the repository's history with a
   short description of the updates.</p>
-<p><code>$ git commit -m "&#60;your commit message&#62;"</code></p>
+<p><code class="shell">git commit -m "&#60;your commit message&#62;"</code></p>
 
 <h2>Step: Make More Changes</h2>
 <p>Now add another line to <code>readme.txt</code> and save.</p>
@@ -154,7 +154,7 @@
 <p>In terminal, you can view the <strong>diff</strong>erence between the
   file now and how it was at your last commit. </p>
 
-<p><code>$ git diff</code></p>
+<p><code class="shell">git diff</code></p>
 
 <p>Now with what you just learned above, commit this latest change.</p>
 
@@ -172,15 +172,15 @@
   <h2>Tips</h2>
   <ul>
     <li><strong>Check status of changes to a repository</strong></li>
-    <li><code>$ git status</code></li>
+    <li><code class="shell">git status</code></li>
     <li><strong>View changes to files</strong></li>
-    <li><code>$ git diff</code></li>
+    <li><code class="shell">git diff</code></li>
     <li><strong>Add a file's changes to be committed</strong></li>
-    <li><code>$ git add &#60;FILENAME&#62;</code></li>
+    <li><code class="shell">git add &#60;FILENAME&#62;</code></li>
     <li><strong>To add all files changes</strong></li>
-    <li><code>$ git add .</code></li>
+    <li><code class="shell">git add .</code></li>
     <li><strong>To commit (aka save) the changes you've added with a short message describing the changes</strong></li>
-    <li><code>$ git commit -m "&#60;your commit message&#62;"</code></li>
+    <li><code class="shell">git commit -m "&#60;your commit message&#62;"</code></li>
   <ul>
 </div>
 

--- a/challenges/forks_and_clones.html
+++ b/challenges/forks_and_clones.html
@@ -152,14 +152,14 @@
   inside of the 'hello-world' repository you worked in on the earlier challenges,
   back out of that folder. You can leave the folder you're in (and be in the folder that it was inside of) by 'changing directory' with two dots:
 
-<p><code>$ cd ..</code></p>
+<p><code class="shell">cd ..</code></p>
 
 Now clone:
 
-<p><code>$ git clone &#60;URLFROMGITHUB&#62;</code></p>
+<p><code class="shell">git clone &#60;URLFROMGITHUB&#62;</code></p>
 
 <p>Go into the folder for the fork it created (in this case, named 'patchwork')</p>
-<p><code>$ cd patchwork</code></p>
+<p><code class="shell">cd patchwork</code></p>
 
 <p>Now you've got a copy of the repository on your computer and it is
   automatically connected to the remote repository (your forked copy)
@@ -175,7 +175,7 @@ Now clone:
 <p>You can name this remote connection anything you want, but often
   people use 'upstream', let's use that for this.</p>
 
-<p><code>$ git remote add upstream https://github.com/jlord/patchwork.git</code></p>
+<p><code class="shell">git remote add upstream https://github.com/jlord/patchwork.git</code></p>
 
 <div class="verify">
   <button class="white" id='verify-challenge'>VERIFY</button>
@@ -191,9 +191,9 @@ Now clone:
   <h2>Tips</h2>
   <ul>
     <li><strong>Add remote connections</strong></li>
-    <li><code>$ git remote add &#60;REMOTENAME&#62; &#60;URL&#62;</code></li>
+    <li><code class="shell">git remote add &#60;REMOTENAME&#62; &#60;URL&#62;</code></li>
     <li><strong>View remote connections</strong></li>
-    <li><code>$ git remote -v</code></li>
+    <li><code class="shell">git remote -v</code></li>
   </ul>
 </div>
 

--- a/challenges/get_git.html
+++ b/challenges/get_git.html
@@ -157,7 +157,7 @@ terminal (which you're using in Git-it!) or Git desktop applications (like GitHu
 <p>Once it is installed, open <strong>terminal</strong> (aka Bash, aka Shell, aka Prompt).
 You can verify that it's really there by typing:</p>
 
-<p><code>$ git --version </code></p>
+<p><code class="shell">git --version </code></p>
 
 <p>This will return the version of Git that you're running and look something like this:</p>
 
@@ -168,9 +168,9 @@ You can verify that it's really there by typing:</p>
 <p>Next, configure Git so it knows who to associate your changes to:</p>
 
 <p>Set your name:</p>
-<p><code>$ git config --global user.name "&#60;Your Name&#62;"</code></p>
+<p><code class="shell">git config --global user.name "&#60;Your Name&#62;"</code></p>
 <p>Now set your email:</p>
-<p><code>$ git config --global user.email "&#60;youremail@example.com&#62;"</code></p>
+<p><code class="shell">git config --global user.email "&#60;youremail@example.com&#62;"</code></p>
 
 <div class="verify">
   <button class="white" id='verify-challenge'>VERIFY</button>

--- a/challenges/githubbin.html
+++ b/challenges/githubbin.html
@@ -143,7 +143,7 @@ which will be needed in order to verify the upcoming challenges. Save it exactly
 
 <p>Add your GitHub username to your configuration:</p>
 
-<code>$ git config --global user.username &#60;USerNamE&#62;</code>
+<code class="shell">git config --global user.username &#60;USerNamE&#62;</code>
 <br><br>
 
 <div class="verify">
@@ -159,7 +159,7 @@ which will be needed in order to verify the upcoming challenges. Save it exactly
   <h4>GitHub & Git config usernames do not match</h4>
   <p>A common error is not having your GitHub username match the case of the one you set with <code>git config</code>. For instance, 'JLord' isn't the same as 'jlord'</p>
   <p>To change your username set with Git, just do the same command you did earlier, but with the correct capitalization:</p>
-  <p><code>$ git config --global user.username &#60;USerNamE&#62;</code></p>
+  <p><code class="shell">git config --global user.username &#60;USerNamE&#62;</code></p>
   <p>When you've made your updates, verify again!</p>
 </div>
 

--- a/challenges/merge_tada.html
+++ b/challenges/merge_tada.html
@@ -134,18 +134,18 @@
 <p>First, move into the branch you want to merge <em>into</em> — in this case,
   branch 'gh-pages'.</p>
 
-<p><code>$ git checkout gh-pages</code></p>
+<p><code class="shell">git checkout gh-pages</code></p>
 
 <p>Now tell Git what branch you want to merge <em>in</em> — in this case,
   your feature branch that begins with "add-".</p>
 
-<p><code>$ git merge &#60;BRANCHNAME&#62;</code></p>
+<p><code class="shell">git merge &#60;BRANCHNAME&#62;</code></p>
 
 <p>Tidy up by deleting your feature branch now that it has been merged.</p>
-<p><code>$ git branch -d &#60;BRANCHNAME&#62;</code></p>
+<p><code class="shell">git branch -d &#60;BRANCHNAME&#62;</code></p>
 
 <p>You can also delete the branch from your fork on GitHub:</p>
-<p><code>$ git push &#60;REMOTENAME&#62; --delete &#60;BRANCHNAME&#62;</code></p>
+<p><code class="shell">git push &#60;REMOTENAME&#62; --delete &#60;BRANCHNAME&#62;</code></p>
 
 <h2>Step: Pull from Upstream</h2>
 <p>And last but not least, if you pull in updates from the original
@@ -154,7 +154,7 @@
 
 <p>To pull from the original upstream:</p>
 
-<p><code>$ git pull upstream gh-pages</code></p>
+<p><code class="shell">git pull upstream gh-pages</code></p>
 
 <h2>Congratulations!</h2>
 <p>You've created local repositories, remote repositories, worked with
@@ -176,15 +176,15 @@
   <h2>Tips</h2>
   <ul>
     <li><strong>Merge a branch into current branch</strong></li>
-    <code>$ git merge &#60;BRANCHNAME&#62;</code>
+    <code class="shell">git merge &#60;BRANCHNAME&#62;</code>
     <li><strong>Change the branch you're working on</strong></li>
-    <code>$ git checkout &#60;BRANCHNAME&#62;</code>
+    <code class="shell">git checkout &#60;BRANCHNAME&#62;</code>
     <li><strong>Delete a local branch</strong></li>
-    <code>$ git branch -d &#60;BRANCHNAME&#62;</code>
+    <code class="shell">git branch -d &#60;BRANCHNAME&#62;</code>
     <li><strong>Delete a remote branch</strong></li>
-    <code>$ git push &#60;REMOTENAME&#62; --delete &#60;BRANCHNAME&#62;</code>
+    <code class="shell">git push &#60;REMOTENAME&#62; --delete &#60;BRANCHNAME&#62;</code>
     <li><strong>Pull from a remote branch</strong></li>
-    <code>$ git pull &#60;REMOTENAME&#62; &#60;BRANCHNAME&#62;</code>
+    <code class="shell">git pull &#60;REMOTENAME&#62; &#60;BRANCHNAME&#62;</code>
   </ul>
 </div>
 

--- a/challenges/pull_never_out_of_date.html
+++ b/challenges/pull_never_out_of_date.html
@@ -135,7 +135,7 @@
 <p>See if Reporobot has made any changes to your 'add-' branch by pulling
   in from the remote named 'origin' on GitHub:</p>
 
-<p><code>$ git pull &lt;REMOTENAME&gt; &lt;BRANCHNAME&gt;</code></p>
+<p><code class="shell">git pull &lt;REMOTENAME&gt; &lt;BRANCHNAME&gt;</code></p>
 
 <p>If nothing's changed, it will tell you 'Already up-to-date'.
   If there are changes, it will merge those changes into your local
@@ -159,11 +159,11 @@
   <h2>TIPS</h2>
     <ul>
     <li><strong>Check Git status</strong></li>
-    <code>$ git status</code>
+    <code class="shell">git status</code>
     <li><strong>Pull in changes from a remote branch</strong></li>
-    <code>$ git pull &lt;REMOTENAME&gt; &lt;REMOTEBRANCH&gt;</code>
+    <code class="shell">git pull &lt;REMOTENAME&gt; &lt;REMOTEBRANCH&gt;</code>
     <li><strong>See changes to the remote before you pull in</strong></li>
-    <code>$ git fetch --dry-run</code>
+    <code class="shell">git fetch --dry-run</code>
   </ul>
 </div>
 

--- a/challenges/remote_control.html
+++ b/challenges/remote_control.html
@@ -176,7 +176,7 @@ repository on GitHub's servers.</p>
 initialized as a Git repository in the earlier challenge, you
 want to tell Git the location of the remote version on GitHub's servers. You can have multiple remotes so each requires a name. For your main one, this is commonly named <code>origin</code>.</p>
 
-<code>$ git remote add origin &lt;URLFROMGITHUB&gt;</code>
+<code class="shell">git remote add origin &lt;URLFROMGITHUB&gt;</code>
 
 <p>Your <strong>local</strong> repository now knows where your <strong>remote</strong> one named 'origin' lives on GitHub's servers. Think of it as adding a name and address on speed dial — now when you need to send something there, you can.</p>
 
@@ -187,7 +187,7 @@ want to tell Git the location of the remote version on GitHub's servers. You can
   just need to tell it what URL to associate with origin. Use this
   command instead of the 'add' one above:</p>
 
-<code>$ git remote set-url origin &lt;URLFROMGITHUB&gt;</code>
+<code class="shell">git remote set-url origin &lt;URLFROMGITHUB&gt;</code>
 </blockquote>
 
 <h2>Step: Push Work to your Remote</h2>
@@ -202,7 +202,7 @@ want to tell Git the location of the remote version on GitHub's servers. You can
 
 <p>In this case, we'll send our branch named 'master' to our remote on GitHub named 'origin'. </p>
 
-<code>$ git push origin master</code>
+<code class="shell">git push origin master</code>
 
 <p>Now go to GitHub and refresh the page of your repository. WOAH!
   Everything is the same locally and remotely. Congrats on your
@@ -222,15 +222,15 @@ want to tell Git the location of the remote version on GitHub's servers. You can
   <h2>Tips</h2>
   <ul>
     <li><strong>Add remote connections</strong></li>
-    <code>$ git remote add &lt;REMOTENAME&gt; &lt;URL&gt;</code>
+    <code class="shell">git remote add &lt;REMOTENAME&gt; &lt;URL&gt;</code>
     <li><strong>Set a URL to a remote</strong></li>
-    <code>$ git remote set-url &lt;REMOTENAME&gt; &lt;URL&gt;</code>
+    <code class="shell">git remote set-url &lt;REMOTENAME&gt; &lt;URL&gt;</code>
     <li><strong>Pull in changes</strong></li>
-    <code>$ git pull &lt;REMOTENAME&gt; &lt;BRANCHNAME&gt;</code>
+    <code class="shell">git pull &lt;REMOTENAME&gt; &lt;BRANCHNAME&gt;</code>
     <li><strong>View remote connections</strong></li>
-    <code>$ git remote -v</code>
+    <code class="shell">git remote -v</code>
     <li><strong>Push changes</strong></li>
-    <code>$ git push &lt;REMOTENAME&gt; &lt;BRANCH&gt;</code>
+    <code class="shell">git push &lt;REMOTENAME&gt; &lt;BRANCH&gt;</code>
   </ul>
 </div>
 

--- a/challenges/repository.html
+++ b/challenges/repository.html
@@ -153,13 +153,13 @@
 <p>You can type these commands one at a time into your terminal window.</p>
 
 <p>To make a new folder:</p>
-<code>$ mkdir hello-world</code>
+<code class="shell">mkdir hello-world</code>
 
 <p>To go into that folder:</p>
-<code>$ cd hello-world</code>
+<code class="shell">cd hello-world</code>
 
 <p>To create a new Git instance for a project:</p>
-<code>$ git init</code>
+<code class="shell">git init</code>
 
 <p>That's it! It will just return you to a new line. If you want to be double-sure that it's a Git repository, type <code>git status</code> and if it doesn't return 'fatal: Not a git repository...', you're golden!</p>
 
@@ -177,13 +177,13 @@
   <h2>Tips</h2>
   <ul>
     <li><strong>Make a new folder (aka directory)</strong></li>
-    <code>$ mkdir &#60;FOLDERNAME&#62;</code>
+    <code class="shell">mkdir &#60;FOLDERNAME&#62;</code>
     <li><strong>Navigate into an existing folder (aka change directory)</strong></li>
-    <code>$ cd &#60;FOLDERNAME&#62;</code>
+    <code class="shell">cd &#60;FOLDERNAME&#62;</code>
     <li><strong>List the items in a folder</strong></li>
-    <code>$ ls </code>
+    <code class="shell">ls </code>
     <li><strong>Turn Git on for a folder</strong></li>
-    <code>$ git init</code>
+    <code class="shell">git init</code>
   </ul>
 </div>
 

--- a/pages-content/dictionary.html
+++ b/pages-content/dictionary.html
@@ -4,11 +4,11 @@
 <div id="git-tips">
   <ul>
     <li><strong>Make a new folder (aka directory)</strong></li>
-    <code>$ mkdir &#60;FOLDERNAME&#62;</code>
+    <code class="shell">mkdir &#60;FOLDERNAME&#62;</code>
     <li><strong>Navigate into an existing folder (aka change directory)</strong></li>
-    <code>$ cd &#60;FOLDERNAME&#62;</code>
+    <code class="shell">cd &#60;FOLDERNAME&#62;</code>
     <li><strong>List the items in a folder</strong></li>
-    <code>$ ls </code>
+    <code class="shell">ls </code>
   </ul>
 </div>
 
@@ -30,19 +30,19 @@
 <div id="git-tips">
   <ul>
     <li><strong>Turn Git on for a folder</strong></li>
-    <code>$ git init</code>
+    <code class="shell">git init</code>
     <li><strong>Check status of changes to a repository</strong></li>
-    <code>$ git status</code>
+    <code class="shell">git status</code>
     <li><strong>View changes to files</strong></li>
-    <code>$ git diff</code>
+    <code class="shell">git diff</code>
     <li><strong>Add a file's changes to be committed</strong></li>
-    <code>$ git add &#60;FILENAME&#62;</code>
+    <code class="shell">git add &#60;FILENAME&#62;</code>
     <li><strong>To add all files changes</strong></li>
-    <code>$ git add .</code>
+    <code class="shell">git add .</code>
     <li><strong>To commit (aka save) the changes you've added with a short message describing the changes</strong></li>
-    <code>$ git commit -m 'your commit message'</code>
+    <code class="shell">git commit -m 'your commit message'</code>
     <li><strong>Copy a repository to your computer</strong></li>
-    <code>$ git clone &#60;URL&#62;</code>
+    <code class="shell">git clone &#60;URL&#62;</code>
   </ul>
 </div>
 
@@ -50,15 +50,15 @@
 <div id="git-tips">
   <ul>
     <li><strong>Create a new branch:</strong></li>
-    <code>$ git branch &#60;BRANCHNAME&#62;</code>
+    <code class="shell">git branch &#60;BRANCHNAME&#62;</code>
     <li><strong>Move onto a branch:</strong></li>
-    <code>$ git checkout &#60;BRANCHNAME&#62;</code>
+    <code class="shell">git checkout &#60;BRANCHNAME&#62;</code>
     <li><strong>You can create and switch to a branch in one line:</strong></li>
-    <code>$ git checkout -b &#60;BRANCHNAME&#62;</code>
+    <code class="shell">git checkout -b &#60;BRANCHNAME&#62;</code>
     <li><strong>List the branches:</strong></li>
-    <code>$ git branch</code>
+    <code class="shell">git branch</code>
     <li><strong>Rename a branch you're currently on:</strong></li>
-    <code>$ git branch -m &#60;NEWBRANCHNAME&#62;</code>
+    <code class="shell">git branch -m &#60;NEWBRANCHNAME&#62;</code>
   </ul>
 </div>
 
@@ -66,11 +66,11 @@
 <div id="git-tips">
   <ul>
     <li><strong>Add remote connections</strong></li>
-    <code>$ git remote add &#60;REMOTENAME&#62; &#60;URL&#62;</code>
+    <code class="shell">git remote add &#60;REMOTENAME&#62; &#60;URL&#62;</code>
     <li><strong>Set a URL to a remote</strong></li>
-    <code>$ git remote set-url &#60;REMOTENAME&#62; <URL></code>
+    <code class="shell">git remote set-url &#60;REMOTENAME&#62; <URL></code>
     <li><strong>View remote connections</strong></li>
-    <code>$ git remote -v</code>
+    <code class="shell">git remote -v</code>
   </ul>
 </div>
 
@@ -78,11 +78,11 @@
 <div id="git-tips">
   <ul>
     <li><strong>Pull in changes</strong></li>
-    <code>$ git pull &#60;REMOTENAME&#62; &#60;BRANCHNAME&#62;</code>
+    <code class="shell">git pull &#60;REMOTENAME&#62; &#60;BRANCHNAME&#62;</code>
     <li><strong>Pull in changes from a remote branch</strong></li>
-    <code>$ git pull <REMOTENAME> <REMOTEBRANCH></code>
+    <code class="shell">git pull <REMOTENAME> <REMOTEBRANCH></code>
     <li><strong>See changes to the remote before you pull in</strong></li>
-    <code>$ git fetch --dry-run</code>
+    <code class="shell">git fetch --dry-run</code>
   </ul>
 </div>
 
@@ -90,9 +90,9 @@
 <div id="git-tips">
   <ul>
     <li><strong>Push changes</strong></li>
-    <code>$ git push &#60;REMOTENAME&#62; <BRANCH></code>
+    <code class="shell">git push &#60;REMOTENAME&#62; <BRANCH></code>
     <li><strong>Merge a branch into current branch</strong></li>
-    <code>$ git merge &#60;BRANCHNAME&#62;</code>
+    <code class="shell">git merge &#60;BRANCHNAME&#62;</code>
   </ul>
 </div>
 
@@ -100,8 +100,8 @@
 <div id="git-tips">
   <ul>
     <li><strong>Delete a local branch</strong></li>
-    <code>$ git branch -D &#60;BRANCHNAME&#62;</code>
+    <code class="shell">git branch -D &#60;BRANCHNAME&#62;</code>
     <li><strong>Delete a remote branch</strong></li>
-    <code>$ git push &#60;REMOTENAME&#62; --delete &#60;BRANCHNAME&#62;</code>
+    <code class="shell">git push &#60;REMOTENAME&#62; --delete &#60;BRANCHNAME&#62;</code>
   </ul>
 </div>

--- a/pages/dictionary.html
+++ b/pages/dictionary.html
@@ -44,11 +44,11 @@
 <div id="git-tips">
   <ul>
     <li><strong>Make a new folder (aka directory)</strong></li>
-    <code>$ mkdir &#60;FOLDERNAME&#62;</code>
+    <code class="shell">mkdir &#60;FOLDERNAME&#62;</code>
     <li><strong>Navigate into an existing folder (aka change directory)</strong></li>
-    <code>$ cd &#60;FOLDERNAME&#62;</code>
+    <code class="shell">cd &#60;FOLDERNAME&#62;</code>
     <li><strong>List the items in a folder</strong></li>
-    <code>$ ls </code>
+    <code class="shell">ls </code>
   </ul>
 </div>
 
@@ -70,19 +70,19 @@
 <div id="git-tips">
   <ul>
     <li><strong>Turn Git on for a folder</strong></li>
-    <code>$ git init</code>
+    <code class="shell">git init</code>
     <li><strong>Check status of changes to a repository</strong></li>
-    <code>$ git status</code>
+    <code class="shell">git status</code>
     <li><strong>View changes to files</strong></li>
-    <code>$ git diff</code>
+    <code class="shell">git diff</code>
     <li><strong>Add a file's changes to be committed</strong></li>
-    <code>$ git add &#60;FILENAME&#62;</code>
+    <code class="shell">git add &#60;FILENAME&#62;</code>
     <li><strong>To add all files changes</strong></li>
-    <code>$ git add .</code>
+    <code class="shell">git add .</code>
     <li><strong>To commit (aka save) the changes you've added with a short message describing the changes</strong></li>
-    <code>$ git commit -m 'your commit message'</code>
+    <code class="shell">git commit -m 'your commit message'</code>
     <li><strong>Copy a repository to your computer</strong></li>
-    <code>$ git clone &#60;URL&#62;</code>
+    <code class="shell">git clone &#60;URL&#62;</code>
   </ul>
 </div>
 
@@ -90,15 +90,15 @@
 <div id="git-tips">
   <ul>
     <li><strong>Create a new branch:</strong></li>
-    <code>$ git branch &#60;BRANCHNAME&#62;</code>
+    <code class="shell">git branch &#60;BRANCHNAME&#62;</code>
     <li><strong>Move onto a branch:</strong></li>
-    <code>$ git checkout &#60;BRANCHNAME&#62;</code>
+    <code class="shell">git checkout &#60;BRANCHNAME&#62;</code>
     <li><strong>You can create and switch to a branch in one line:</strong></li>
-    <code>$ git checkout -b &#60;BRANCHNAME&#62;</code>
+    <code class="shell">git checkout -b &#60;BRANCHNAME&#62;</code>
     <li><strong>List the branches:</strong></li>
-    <code>$ git branch</code>
+    <code class="shell">git branch</code>
     <li><strong>Rename a branch you're currently on:</strong></li>
-    <code>$ git branch -m &#60;NEWBRANCHNAME&#62;</code>
+    <code class="shell">git branch -m &#60;NEWBRANCHNAME&#62;</code>
   </ul>
 </div>
 
@@ -106,11 +106,11 @@
 <div id="git-tips">
   <ul>
     <li><strong>Add remote connections</strong></li>
-    <code>$ git remote add &#60;REMOTENAME&#62; &#60;URL&#62;</code>
+    <code class="shell">git remote add &#60;REMOTENAME&#62; &#60;URL&#62;</code>
     <li><strong>Set a URL to a remote</strong></li>
-    <code>$ git remote set-url &#60;REMOTENAME&#62; <URL></code>
+    <code class="shell">git remote set-url &#60;REMOTENAME&#62; <URL></code>
     <li><strong>View remote connections</strong></li>
-    <code>$ git remote -v</code>
+    <code class="shell">git remote -v</code>
   </ul>
 </div>
 
@@ -118,11 +118,11 @@
 <div id="git-tips">
   <ul>
     <li><strong>Pull in changes</strong></li>
-    <code>$ git pull &#60;REMOTENAME&#62; &#60;BRANCHNAME&#62;</code>
+    <code class="shell">git pull &#60;REMOTENAME&#62; &#60;BRANCHNAME&#62;</code>
     <li><strong>Pull in changes from a remote branch</strong></li>
-    <code>$ git pull <REMOTENAME> <REMOTEBRANCH></code>
+    <code class="shell">git pull <REMOTENAME> <REMOTEBRANCH></code>
     <li><strong>See changes to the remote before you pull in</strong></li>
-    <code>$ git fetch --dry-run</code>
+    <code class="shell">git fetch --dry-run</code>
   </ul>
 </div>
 
@@ -130,9 +130,9 @@
 <div id="git-tips">
   <ul>
     <li><strong>Push changes</strong></li>
-    <code>$ git push &#60;REMOTENAME&#62; <BRANCH></code>
+    <code class="shell">git push &#60;REMOTENAME&#62; <BRANCH></code>
     <li><strong>Merge a branch into current branch</strong></li>
-    <code>$ git merge &#60;BRANCHNAME&#62;</code>
+    <code class="shell">git merge &#60;BRANCHNAME&#62;</code>
   </ul>
 </div>
 
@@ -140,9 +140,9 @@
 <div id="git-tips">
   <ul>
     <li><strong>Delete a local branch</strong></li>
-    <code>$ git branch -D &#60;BRANCHNAME&#62;</code>
+    <code class="shell">git branch -D &#60;BRANCHNAME&#62;</code>
     <li><strong>Delete a remote branch</strong></li>
-    <code>$ git push &#60;REMOTENAME&#62; --delete &#60;BRANCHNAME&#62;</code>
+    <code class="shell">git push &#60;REMOTENAME&#62; --delete &#60;BRANCHNAME&#62;</code>
   </ul>
 </div>
 


### PR DESCRIPTION
This patch replaces all of these:

```html
<code>$ fooby dooby</code>
```

with this:

```html
<code class="shell">fooby dooby</code>
```

and uses a CSS `:before` element to make the `$` still visible, but not selectable.

![shell-prompts](https://cloud.githubusercontent.com/assets/2289/11018111/8095cfac-857e-11e5-94c7-f90c32b085bd.gif)