### PR TITLE
Test main.js with Spectron

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,15 @@
   "name": "git-it-electron",
   "version": "2.0.0",
   "description": "An open source desktop app for learning Git and GitHub",
-  "keywords": ["Git", "GitHub", "Git-it", "tutorial", "guide", "learn", "desktop"],
+  "keywords": [
+    "Git",
+    "GitHub",
+    "Git-it",
+    "tutorial",
+    "guide",
+    "learn",
+    "desktop"
+  ],
   "productName": "Git-it",
   "main": "main.js",
   "scripts": {
@@ -28,7 +36,9 @@
   },
   "homepage": "https://github.com/jlord/git-it-electron",
   "devDependencies": {
-    "electron-prebuilt": "^0.33.0"
+    "electron-prebuilt": "^0.33.0",
+    "spectron": "^0.34.0",
+    "tape": "^4.2.2"
   },
   "dependencies": {
     "cheerio": "^0.19.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "homepage": "https://github.com/jlord/git-it-electron",
   "devDependencies": {
     "electron-prebuilt": "^0.33.0",
-    "spectron": "^0.34.0",
+    "spectron": "^0.34.1",
     "tape": "^4.2.2"
   },
   "dependencies": {

--- a/tests/test-main.js
+++ b/tests/test-main.js
@@ -20,10 +20,10 @@ function wrapper(description, fn) {
     test(description, function(t) {
         setup()
             .then(function() {
-                fn(t)
+                return fn(t)
             })
             .then(function() {
-                teardown()
+                return teardown()
             })
     })
 }

--- a/tests/test-main.js
+++ b/tests/test-main.js
@@ -1,0 +1,51 @@
+var Application = require('spectron').Application
+var test = require('tape')
+
+// pass the path to the built application from the command line
+var path = process.argv[2]
+
+function setup() {
+    this.app = new Application({
+        path: path
+    })
+    return this.app.start()
+}
+
+function teardown() {
+    if (this.app && this.app.isRunning()) {
+        this.app.stop()
+    }
+}
+function wrapper(description, fn) {
+    test(description, function(t) {
+        setup()
+            .then(function() {
+                fn(t)
+            })
+            .then(function() {
+                teardown()
+            })
+    })
+}
+wrapper('application launch', function(t) {
+    this.app.client.getWindowCount().then(function(count) {
+        t.equal(count, 1)
+    })
+    this.app.client.isWindowMinimized().then(function(truth) {
+        t.false(truth)
+    })
+    this.app.client.isWindowDevToolsOpened().then(function(truth) {
+        t.false(truth)
+    })
+    this.app.client.isWindowVisible().then(function(truth) {
+        t.true(truth)
+    })
+    this.app.client.isWindowFocused().then(function(truth) {
+        t.true(truth)
+    })
+    this.app.client.getWindowDimensions().then(function(dimensions) {
+        t.equal(dimensions.height, 600)
+        t.equal(dimensions.width, 900)
+    })
+    t.end()
+})

--- a/tests/test-main.js
+++ b/tests/test-main.js
@@ -4,56 +4,77 @@ var test = require('tape')
 // pass the path to the built application from the command line
 var path = process.argv[2]
 
-function setup() {
-    app = new Application({
-        path: path
-    })
-    return app.start()
+var app = null
+
+function setup () {
+  app = new Application({
+    path: path
+  })
+  return app.start()
 }
 
-function teardown() {
-    if (app && app.isRunning()) {
-        app.stop()
-    }
-}
-function wrapper(description, fn) {
-    test(description, function(t) {
-        setup()
-            .then(function() {
-                return fn(t)
-            })
-            .then(function() {
-                return teardown()
-            })
-
+function teardown (t) {
+  if (app && app.isRunning()) {
+    return app.stop().then(function () {
+      t.end()
+    }, function (error) {
+      t.end(error)
     })
-}
-wrapper('upon application launch', function(t) {
-    app.client.getWindowCount().then(function(count) {
-        t.equal(count, 1, 'client window count should equal 1')
-    })
-    app.client.isWindowMinimized().then(function(truth) {
-        t.false(truth, 'client window should not be minimized')
-    })
-    app.client.isWindowDevToolsOpened().then(function(truth) {
-        t.false(truth, 'client window\'s dev tools should not be opened')
-    })
-    app.client.isWindowVisible().then(function(truth) {
-        t.true(truth, 'client window should be visible')
-    })
-    app.client.isWindowFocused().then(function(truth) {
-        t.true(truth, 'client window should be in focus')
-    })
-    app.client.getWindowDimensions().then(function(dimensions) {
-        t.equal(dimensions.height, 600, 'client window height should equal 600')
-    })
-    app.client.getWindowDimensions().then(function(dimensions) {
-        t.equal(dimensions.width, 900, 'client window width should equal 900')
-    })
-    // getWindowHeight and getWindowWidth currently fail with Tape
-    // Use ^ instead of getWindowDimensions when issue is resolved
-    //this.app.client.getWindowHeight().then(function(height) {
-    //    t.equal(height, 600)
-    //})
+  } else {
     t.end()
+  }
+}
+function wrapper (description, fn) {
+  test(description, function (t) {
+    setup()
+      .then(function () {
+        return fn(t)
+      })
+      .then(function () {
+        return teardown(t)
+      })
+
+  })
+}
+
+wrapper('getWindowCount launch', function (t) {
+  return app.client.getWindowCount().then(function (count) {
+    t.equal(count, 1, 'client window count should equal 1')
+  })
+})
+
+wrapper('isWindowMinimized test', function (t) {
+  return app.client.isWindowMinimized().then(function (truth) {
+    t.false(truth, 'client window should not be minimized')
+  })
+})
+
+wrapper('isWindowDevToolsOpened test', function (t) {
+  return app.client.isWindowDevToolsOpened().then(function (truth) {
+    t.false(truth, 'client window\'s dev tools should not be opened')
+  })
+})
+
+wrapper('isWindowVisible test', function (t) {
+  return app.client.isWindowVisible().then(function (truth) {
+    t.true(truth, 'client window should be visible')
+  })
+})
+
+wrapper('isWindowFocused test', function (t) {
+  return app.client.isWindowFocused().then(function (truth) {
+    t.true(truth, 'client window should be in focus')
+  })
+})
+
+wrapper('getWindowHeight test', function (t) {
+  return app.client.getWindowHeight().then(function (height) {
+    t.equal(height, 600, 'client window height should equal 600')
+  })
+})
+
+wrapper('getWindowWidth test', function (t) {
+  return app.client.getWindowWidth().then(function (width) {
+    t.equal(width, 900, 'client window width should equal 900')
+  })
 })

--- a/tests/test-main.js
+++ b/tests/test-main.js
@@ -27,25 +27,32 @@ function wrapper(description, fn) {
             })
     })
 }
-wrapper('application launch', function(t) {
+wrapper('upon application launch', function(t) {
     this.app.client.getWindowCount().then(function(count) {
-        t.equal(count, 1)
+        t.equal(count, 1, 'client window count should equal 1')
     })
     this.app.client.isWindowMinimized().then(function(truth) {
-        t.false(truth)
+        t.false(truth, 'client window should not be minimized')
     })
     this.app.client.isWindowDevToolsOpened().then(function(truth) {
-        t.false(truth)
+        t.false(truth, 'client window\'s dev tools should not be opened')
     })
     this.app.client.isWindowVisible().then(function(truth) {
-        t.true(truth)
+        t.true(truth, 'client window should be visible')
     })
     this.app.client.isWindowFocused().then(function(truth) {
-        t.true(truth)
+        t.true(truth, 'client window should be in focus')
     })
     this.app.client.getWindowDimensions().then(function(dimensions) {
-        t.equal(dimensions.height, 600)
-        t.equal(dimensions.width, 900)
+        t.equal(dimensions.height, 600, 'client window height should equal 600')
     })
+    this.app.client.getWindowDimensions().then(function(dimensions) {
+        t.equal(dimensions.width, 900, 'client window width should equal 900')
+    })
+    // getWindowHeight and getWindowWidth currently fail with Tape
+    // Use ^ instead of getWindowDimensions when issue is resolved
+    //this.app.client.getWindowHeight().then(function(height) {
+    //    t.equal(height, 600)
+    //})
     t.end()
 })

--- a/tests/test-main.js
+++ b/tests/test-main.js
@@ -5,15 +5,15 @@ var test = require('tape')
 var path = process.argv[2]
 
 function setup() {
-    this.app = new Application({
+    app = new Application({
         path: path
     })
-    return this.app.start()
+    return app.start()
 }
 
 function teardown() {
-    if (this.app && this.app.isRunning()) {
-        this.app.stop()
+    if (app && app.isRunning()) {
+        app.stop()
     }
 }
 function wrapper(description, fn) {
@@ -25,28 +25,29 @@ function wrapper(description, fn) {
             .then(function() {
                 return teardown()
             })
+
     })
 }
 wrapper('upon application launch', function(t) {
-    this.app.client.getWindowCount().then(function(count) {
+    app.client.getWindowCount().then(function(count) {
         t.equal(count, 1, 'client window count should equal 1')
     })
-    this.app.client.isWindowMinimized().then(function(truth) {
+    app.client.isWindowMinimized().then(function(truth) {
         t.false(truth, 'client window should not be minimized')
     })
-    this.app.client.isWindowDevToolsOpened().then(function(truth) {
+    app.client.isWindowDevToolsOpened().then(function(truth) {
         t.false(truth, 'client window\'s dev tools should not be opened')
     })
-    this.app.client.isWindowVisible().then(function(truth) {
+    app.client.isWindowVisible().then(function(truth) {
         t.true(truth, 'client window should be visible')
     })
-    this.app.client.isWindowFocused().then(function(truth) {
+    app.client.isWindowFocused().then(function(truth) {
         t.true(truth, 'client window should be in focus')
     })
-    this.app.client.getWindowDimensions().then(function(dimensions) {
+    app.client.getWindowDimensions().then(function(dimensions) {
         t.equal(dimensions.height, 600, 'client window height should equal 600')
     })
-    this.app.client.getWindowDimensions().then(function(dimensions) {
+    app.client.getWindowDimensions().then(function(dimensions) {
         t.equal(dimensions.width, 900, 'client window width should equal 900')
     })
     // getWindowHeight and getWindowWidth currently fail with Tape


### PR DESCRIPTION
I haven't forgotten about adding automated tests for the verify modules but still trying to grok the newness of much of this (Electron, Tape, the app itself, etc). However, I was playing around this weekend with Spectron after seeing [this talk](https://speakerdeck.com/kevinsawicki/testing-your-electron-apps-with-chromedriver) this past week and wanted see if something like this would be useful for testing the packages. 

You'll notice in test-main.js that there is a wrapper function that controls the flow by setting up (creates new app object and starts it), running the tests, and then tearing down (stops the app if it's still running) but being new to Tape I'd be interested in learning if there's a better way to do this.  

``` javascript
function wrapper(description, fn) {
    test(description, function(t) {
        setup()
            .then(function() {
                return fn(t)
            })
            .then(function() {
                return teardown()
            })
    })
}
```

The tests themselves are currently sanity checks (making sure that the electron app window is visible, the specified size, etc) but can be expanded if desired. 

I'm running the tests locally against a packaged app with this command so that the path to the executable doesn't have to be hard-coded in test-main.js

```
node tests/test-main.js <path to the electron executable> 
```

As a note, I haven't run the tests on windows or linux. 

I'd love to hear your thoughts. If it is something you're interested in I'll write up some documentation on how to run the tests locally in CONTRIBUTING.md. 
