### PR TITLE
Add Pages and Languages to Menu

### DIFF
--- a/challenges/branches_arent_just_for_birds.html
+++ b/challenges/branches_arent_just_for_birds.html
@@ -242,17 +242,6 @@ GitHub Guide: <a href="http://guides.github.com/overviews/flow/" target="_blank"
     </a>
   </div>
 </div>
-<footer>
-  <ul>
-    <li class="all-caps"><a href="../index.html"><strong>Git-it Challenges</strong></a></li>
-    <li class="all-caps"><a href="../pages/about.html">About</a></li>
-    <li class="all-caps"><a href="../pages/dictionary.html">Dictionary</a></li>
-    <li class="all-caps"><a href="../pages/resources.html">Resources</a></li>
-    <li class="all-caps">
-      <a href="http://github.com/jlord/git-it/issues/new" target="_blank">Open an Issue</a>
-    </li>
-  </ul>
-</footer>
       </div>
     </div>
 

--- a/challenges/commit_to_it.html
+++ b/challenges/commit_to_it.html
@@ -197,17 +197,6 @@
     </a>
   </div>
 </div>
-<footer>
-  <ul>
-    <li class="all-caps"><a href="../index.html"><strong>Git-it Challenges</strong></a></li>
-    <li class="all-caps"><a href="../pages/about.html">About</a></li>
-    <li class="all-caps"><a href="../pages/dictionary.html">Dictionary</a></li>
-    <li class="all-caps"><a href="../pages/resources.html">Resources</a></li>
-    <li class="all-caps">
-      <a href="http://github.com/jlord/git-it/issues/new" target="_blank">Open an Issue</a>
-    </li>
-  </ul>
-</footer>
       </div>
     </div>
 

--- a/challenges/forks_and_clones.html
+++ b/challenges/forks_and_clones.html
@@ -212,17 +212,6 @@ Now clone:
     </a>
   </div>
 </div>
-<footer>
-  <ul>
-    <li class="all-caps"><a href="../index.html"><strong>Git-it Challenges</strong></a></li>
-    <li class="all-caps"><a href="../pages/about.html">About</a></li>
-    <li class="all-caps"><a href="../pages/dictionary.html">Dictionary</a></li>
-    <li class="all-caps"><a href="../pages/resources.html">Resources</a></li>
-    <li class="all-caps">
-      <a href="http://github.com/jlord/git-it/issues/new" target="_blank">Open an Issue</a>
-    </li>
-  </ul>
-</footer>
       </div>
     </div>
 

--- a/challenges/get_git.html
+++ b/challenges/get_git.html
@@ -199,17 +199,6 @@ type the <code>$</code> in though, only type what comes after. For instance, to 
     </a>
   </div>
 </div>
-<footer>
-  <ul>
-    <li class="all-caps"><a href="../index.html"><strong>Git-it Challenges</strong></a></li>
-    <li class="all-caps"><a href="../pages/about.html">About</a></li>
-    <li class="all-caps"><a href="../pages/dictionary.html">Dictionary</a></li>
-    <li class="all-caps"><a href="../pages/resources.html">Resources</a></li>
-    <li class="all-caps">
-      <a href="http://github.com/jlord/git-it/issues/new" target="_blank">Open an Issue</a>
-    </li>
-  </ul>
-</footer>
       </div>
     </div>
 

--- a/challenges/githubbin.html
+++ b/challenges/githubbin.html
@@ -176,17 +176,6 @@ which will be needed in order to verify the upcoming challenges. Save it exactly
     </a>
   </div>
 </div>
-<footer>
-  <ul>
-    <li class="all-caps"><a href="../index.html"><strong>Git-it Challenges</strong></a></li>
-    <li class="all-caps"><a href="../pages/about.html">About</a></li>
-    <li class="all-caps"><a href="../pages/dictionary.html">Dictionary</a></li>
-    <li class="all-caps"><a href="../pages/resources.html">Resources</a></li>
-    <li class="all-caps">
-      <a href="http://github.com/jlord/git-it/issues/new" target="_blank">Open an Issue</a>
-    </li>
-  </ul>
-</footer>
       </div>
     </div>
 

--- a/challenges/its_a_small_world.html
+++ b/challenges/its_a_small_world.html
@@ -164,17 +164,6 @@
     </a>
   </div>
 </div>
-<footer>
-  <ul>
-    <li class="all-caps"><a href="../index.html"><strong>Git-it Challenges</strong></a></li>
-    <li class="all-caps"><a href="../pages/about.html">About</a></li>
-    <li class="all-caps"><a href="../pages/dictionary.html">Dictionary</a></li>
-    <li class="all-caps"><a href="../pages/resources.html">Resources</a></li>
-    <li class="all-caps">
-      <a href="http://github.com/jlord/git-it/issues/new" target="_blank">Open an Issue</a>
-    </li>
-  </ul>
-</footer>
       </div>
     </div>
 

--- a/challenges/merge_tada.html
+++ b/challenges/merge_tada.html
@@ -201,17 +201,6 @@
     </a>
   </div>
 </div>
-<footer>
-  <ul>
-    <li class="all-caps"><a href="../index.html"><strong>Git-it Challenges</strong></a></li>
-    <li class="all-caps"><a href="../pages/about.html">About</a></li>
-    <li class="all-caps"><a href="../pages/dictionary.html">Dictionary</a></li>
-    <li class="all-caps"><a href="../pages/resources.html">Resources</a></li>
-    <li class="all-caps">
-      <a href="http://github.com/jlord/git-it/issues/new" target="_blank">Open an Issue</a>
-    </li>
-  </ul>
-</footer>
       </div>
     </div>
 

--- a/challenges/pull_never_out_of_date.html
+++ b/challenges/pull_never_out_of_date.html
@@ -180,17 +180,6 @@
     </a>
   </div>
 </div>
-<footer>
-  <ul>
-    <li class="all-caps"><a href="../index.html"><strong>Git-it Challenges</strong></a></li>
-    <li class="all-caps"><a href="../pages/about.html">About</a></li>
-    <li class="all-caps"><a href="../pages/dictionary.html">Dictionary</a></li>
-    <li class="all-caps"><a href="../pages/resources.html">Resources</a></li>
-    <li class="all-caps">
-      <a href="http://github.com/jlord/git-it/issues/new" target="_blank">Open an Issue</a>
-    </li>
-  </ul>
-</footer>
       </div>
     </div>
 

--- a/challenges/remote_control.html
+++ b/challenges/remote_control.html
@@ -247,17 +247,6 @@ want to tell Git the location of the remote version on GitHub's servers. You can
     </a>
   </div>
 </div>
-<footer>
-  <ul>
-    <li class="all-caps"><a href="../index.html"><strong>Git-it Challenges</strong></a></li>
-    <li class="all-caps"><a href="../pages/about.html">About</a></li>
-    <li class="all-caps"><a href="../pages/dictionary.html">Dictionary</a></li>
-    <li class="all-caps"><a href="../pages/resources.html">Resources</a></li>
-    <li class="all-caps">
-      <a href="http://github.com/jlord/git-it/issues/new" target="_blank">Open an Issue</a>
-    </li>
-  </ul>
-</footer>
       </div>
     </div>
 

--- a/challenges/repository.html
+++ b/challenges/repository.html
@@ -200,17 +200,6 @@
     </a>
   </div>
 </div>
-<footer>
-  <ul>
-    <li class="all-caps"><a href="../index.html"><strong>Git-it Challenges</strong></a></li>
-    <li class="all-caps"><a href="../pages/about.html">About</a></li>
-    <li class="all-caps"><a href="../pages/dictionary.html">Dictionary</a></li>
-    <li class="all-caps"><a href="../pages/resources.html">Resources</a></li>
-    <li class="all-caps">
-      <a href="http://github.com/jlord/git-it/issues/new" target="_blank">Open an Issue</a>
-    </li>
-  </ul>
-</footer>
       </div>
     </div>
 

--- a/challenges/requesting_you_pull_please.html
+++ b/challenges/requesting_you_pull_please.html
@@ -196,17 +196,6 @@ request.</p>
     </a>
   </div>
 </div>
-<footer>
-  <ul>
-    <li class="all-caps"><a href="../index.html"><strong>Git-it Challenges</strong></a></li>
-    <li class="all-caps"><a href="../pages/about.html">About</a></li>
-    <li class="all-caps"><a href="../pages/dictionary.html">Dictionary</a></li>
-    <li class="all-caps"><a href="../pages/resources.html">Resources</a></li>
-    <li class="all-caps">
-      <a href="http://github.com/jlord/git-it/issues/new" target="_blank">Open an Issue</a>
-    </li>
-  </ul>
-</footer>
       </div>
     </div>
 

--- a/index.html
+++ b/index.html
@@ -50,18 +50,6 @@
 
       <button id="clear-all-challenges">Clear all challenge statues</button>
 
-      <footer>
-        <ul>
-          <li class="all-caps"><a href="index.html"><strong>Git-it Challenges</strong></a></li>
-          <li class="all-caps"><a href="./pages/about.html">About</a></li>
-          <li class="all-caps"><a href="./pages/dictionary.html">Dictionary</a></li>
-          <li class="all-caps"><a href="./pages/resources.html">Resources</a></li>
-          <li class="all-caps">
-            <a href="http://github.com/jlord/git-it/issues/new" target="_blank">Open an Issue</a>
-          </li>
-        </ul>
-      </footer>
-
     </div>
     <script src="./lib/languages.js"></script>
   </body>

--- a/layouts/page.hbs
+++ b/layouts/page.hbs
@@ -16,7 +16,6 @@
 
     <div class="page-wrapper">
       {{{ body }}}
-      {{{ footer }}}
     </div>
 
   </body>

--- a/menus/darwin-menu.js
+++ b/menus/darwin-menu.js
@@ -100,6 +100,58 @@ module.exports = function menu (app, mainWindow) {
       ]
     },
     {
+    label: 'Language',
+    submenu: [
+      {
+        label: 'English',
+        click: function (item, focusedWindow) {
+          if (focusedWindow) {
+            var path = ''
+            var currentPage = focusedWindow.webContents.getURL().split('/').pop().replace('.html', '')
+            if (currentPage.match('zhtw') || currentPage.match('ja')) currentPage = currentPage.split('-')[0]
+            var langPage = currentPage + '.html'
+            if (langPage.indexOf('index') < 0) {
+              path = require('path').join('file://', __dirname, '../challenges', langPage)
+            } else path = require('path').join('file://', __dirname, '../', langPage)
+            focusedWindow.loadURL(path)
+          }
+        }
+      },
+      {
+        label: '正體中文',
+        click: function (item, focusedWindow) {
+          if (focusedWindow) {
+            var path = ''
+            var lang = '-zhtw'
+            var currentPage = focusedWindow.webContents.getURL().split('/').pop().replace('.html', '')
+            if (currentPage.match('zhtw') || currentPage.match('ja')) currentPage = currentPage.split('-')[0]
+            var langPage = currentPage + lang + '.html'
+            if (langPage.indexOf('index') < 0) {
+              path = require('path').join('file://', __dirname, '../challenges', langPage)
+            } else path = require('path').join('file://', __dirname, '../', langPage)
+            focusedWindow.loadURL(path)
+          }
+        }
+      },
+      {
+        label: '日本語',
+        click: function (item, focusedWindow) {
+          if (focusedWindow) {
+            var path = ''
+            var lang = '-ja'
+            var currentPage = focusedWindow.webContents.getURL().split('/').pop().replace('.html', '')
+            if (currentPage.match('zhtw') || currentPage.match('ja')) currentPage = currentPage.split('-')[0]
+            var langPage = currentPage + lang + '.html'
+            if (langPage.indexOf('index') < 0) {
+              path = require('path').join('file://', __dirname, '../challenges', langPage)
+            } else path = require('path').join('file://', __dirname, '../', langPage)
+            focusedWindow.loadURL(path)
+          }
+        }
+      }
+    ]
+    },
+    {
       label: 'Window',
       submenu: [
         {

--- a/menus/darwin-menu.js
+++ b/menus/darwin-menu.js
@@ -100,66 +100,75 @@ module.exports = function menu (app, mainWindow) {
       ]
     },
     {
-    label: 'Language',
-    submenu: [
-      {
-        label: 'English',
-        click: function (item, focusedWindow) {
-          if (focusedWindow) {
-            var goToPath
-            var location = focusedWindow.webContents.getURL()
-            var currentPage = location.split('/').pop().replace('.html', '')
-            if (currentPage.indexOf('index') < 0) {
-              if (location.match('/pages/')) return goToPath = location
-              goToPath = require('path').join('file://', __dirname, '../challenges', currentPage + '.html')
-            } else {
-              goToPath = require('path').join('file://', __dirname, '../index.html')
+      label: 'Language',
+      submenu: [
+        {
+          label: 'English',
+          click: function (item, focusedWindow) {
+            if (focusedWindow) {
+              var goToPath
+              var location = focusedWindow.webContents.getURL()
+              var currentPage = location.split('/').pop().replace('.html', '')
+              if (currentPage.indexOf('index') < 0) {
+                if (location.match('/pages/')) {
+                  goToPath = location
+                  return
+                }
+                goToPath = require('path').join('file://', __dirname, '../challenges', currentPage + '.html')
+              } else {
+                goToPath = require('path').join('file://', __dirname, '../index.html')
+              }
+              focusedWindow.loadURL(goToPath)
             }
-            focusedWindow.loadURL(goToPath)
+          }
+        },
+        {
+          label: '正體中文',
+          click: function (item, focusedWindow) {
+            if (focusedWindow) {
+              var goToPath
+              var lang = '-zhtw'
+              var location = focusedWindow.webContents.getURL()
+              var currentPage = location.split('/').pop().replace('.html', '')
+              if (currentPage.indexOf('index') < 0) {
+                if (location.match('/pages/')) {
+                  goToPath = location
+                  return
+                }
+                var chalPath = '../challenges' + lang
+                goToPath = require('path').join('file://', __dirname, chalPath, currentPage + '.html')
+              } else {
+                var indexPath = '../index' + lang + '.html'
+                goToPath = require('path').join('file://', __dirname, indexPath)
+              }
+              focusedWindow.loadURL(goToPath)
+            }
+          }
+        },
+        {
+          label: '日本語',
+          click: function (item, focusedWindow) {
+            if (focusedWindow) {
+              var goToPath
+              var lang = '-ja'
+              var location = focusedWindow.webContents.getURL()
+              var currentPage = location.split('/').pop().replace('.html', '')
+              if (currentPage.indexOf('index') < 0) {
+                if (location.match('/pages/')) {
+                  goToPath = location
+                  return
+                }
+                var chalPath = '../challenges' + lang
+                goToPath = require('path').join('file://', __dirname, chalPath, currentPage + '.html')
+              } else {
+                var indexPath = '../index' + lang + '.html'
+                goToPath = require('path').join('file://', __dirname, indexPath)
+              }
+              focusedWindow.loadURL(goToPath)
+            }
           }
         }
-      },
-      {
-        label: '正體中文',
-        click: function (item, focusedWindow) {
-          if (focusedWindow) {
-            var goToPath
-            var lang = '-zhtw'
-            var location = focusedWindow.webContents.getURL()
-            var currentPage = location.split('/').pop().replace('.html', '')
-            if (currentPage.indexOf('index') < 0) {
-              if (location.match('/pages/')) return goToPath = location
-              var chalPath = '../challenges' + lang
-              goToPath = require('path').join('file://', __dirname, chalPath, currentPage + '.html')
-            } else {
-              var indexPath = '../index' + lang + '.html'
-              goToPath = require('path').join('file://', __dirname, indexPath)
-            }
-            focusedWindow.loadURL(goToPath)
-          }
-        }
-      },
-      {
-        label: '日本語',
-        click: function (item, focusedWindow) {
-          if (focusedWindow) {
-            var goToPath
-            var lang = '-ja'
-            var location = focusedWindow.webContents.getURL()
-            var currentPage = location.split('/').pop().replace('.html', '')
-            if (currentPage.indexOf('index') < 0) {
-              if (location.match('/pages/')) return goToPath = location
-              var chalPath = '../challenges' + lang
-              goToPath = require('path').join('file://', __dirname, chalPath, currentPage + '.html')
-            } else {
-              var indexPath = '../index' + lang + '.html'
-              goToPath = require('path').join('file://', __dirname, indexPath)
-            }
-            focusedWindow.loadURL(goToPath)
-          }
-        }
-      }
-    ]
+      ]
     },
     {
       label: 'Window',
@@ -167,7 +176,7 @@ module.exports = function menu (app, mainWindow) {
         {
           label: 'Home',
           click: function (item, focusedWindow) {
-            if (focusedWindow)
+            if (focusedWindow) {
               var lang, regexp
               var location = focusedWindow.webContents.getURL()
               var currentPage = location.split('/').pop().replace('.html', '')
@@ -177,35 +186,39 @@ module.exports = function menu (app, mainWindow) {
               var page = '../index' + lang + '.html'
               var path = require('path').join('file://', __dirname, page)
               focusedWindow.loadURL(path)
+            }
           }
         },
         {
           label: 'Dictionary',
           click: function (item, focusedWindow) {
-            if (focusedWindow)
+            if (focusedWindow) {
               var path = require('path').join('file://', __dirname, '../pages/dictionary.html')
               focusedWindow.loadURL(path)
+            }
           }
         },
         {
           label: 'Resources',
           click: function (item, focusedWindow) {
-            if (focusedWindow)
+            if (focusedWindow) {
               var path = require('path').join('file://', __dirname, '../pages/resources.html')
               focusedWindow.loadURL(path)
+            }
           }
         },
         {
           label: 'About App',
           click: function (item, focusedWindow) {
-            if (focusedWindow)
+            if (focusedWindow) {
               var path = require('path').join('file://', __dirname, '../pages/about.html')
               focusedWindow.loadURL(path)
+            }
           }
         },
         {
           label: 'Open Issue',
-          click: function() { require('electron').shell.openExternal('https://github.com/jlord/git-it-electron/issues/new') }
+          click: function () { require('electron').shell.openExternal('https://github.com/jlord/git-it-electron/issues/new') }
         },
         {
           type: 'separator'

--- a/menus/darwin-menu.js
+++ b/menus/darwin-menu.js
@@ -103,6 +103,46 @@ module.exports = function menu (app, mainWindow) {
       label: 'Window',
       submenu: [
         {
+          label: 'Home',
+          click: function (item, focusedWindow) {
+            if (focusedWindow)
+              // TODO Add logic for language specific pages
+              var path = require('path').join('file://', __dirname, '../index.html')
+              focusedWindow.loadURL(path)
+          }
+        },
+        {
+          label: 'Dictionary',
+          click: function (item, focusedWindow) {
+            if (focusedWindow)
+              var path = require('path').join('file://', __dirname, '../pages/dictionary.html')
+              focusedWindow.loadURL(path)
+          }
+        },
+        {
+          label: 'Resources',
+          click: function (item, focusedWindow) {
+            if (focusedWindow)
+              var path = require('path').join('file://', __dirname, '../pages/resources.html')
+              focusedWindow.loadURL(path)
+          }
+        },
+        {
+          label: 'About App',
+          click: function (item, focusedWindow) {
+            if (focusedWindow)
+              var path = require('path').join('file://', __dirname, '../pages/about.html')
+              focusedWindow.loadURL(path)
+          }
+        },
+        {
+          label: 'Open Issue',
+          click: function() { require('electron').shell.openExternal('https://github.com/jlord/git-it-electron/issues/new') }
+        },
+        {
+          type: 'separator'
+        },
+        {
           label: 'Minimize',
           accelerator: 'Command+M',
           selector: 'performMiniaturize:'

--- a/menus/darwin-menu.js
+++ b/menus/darwin-menu.js
@@ -158,8 +158,14 @@ module.exports = function menu (app, mainWindow) {
           label: 'Home',
           click: function (item, focusedWindow) {
             if (focusedWindow)
-              // TODO Add logic for language specific pages
-              var path = require('path').join('file://', __dirname, '../index.html')
+              var lang, regexp
+              var location = focusedWindow.webContents.getURL()
+              var currentPage = location.split('/').pop().replace('.html', '')
+              if (currentPage.match('index')) regexp = /index(-\w+).html/
+              else regexp = /challenges(-\w+)\//
+              lang = location.match(regexp) ? '-' + location.match(regexp)[1].substr(1) : ''
+              var page = '../index' + lang + '.html'
+              var path = require('path').join('file://', __dirname, page)
               focusedWindow.loadURL(path)
           }
         },

--- a/menus/darwin-menu.js
+++ b/menus/darwin-menu.js
@@ -106,14 +106,16 @@ module.exports = function menu (app, mainWindow) {
         label: 'English',
         click: function (item, focusedWindow) {
           if (focusedWindow) {
-            var path = ''
-            var currentPage = focusedWindow.webContents.getURL().split('/').pop().replace('.html', '')
-            if (currentPage.match('zhtw') || currentPage.match('ja')) currentPage = currentPage.split('-')[0]
-            var langPage = currentPage + '.html'
-            if (langPage.indexOf('index') < 0) {
-              path = require('path').join('file://', __dirname, '../challenges', langPage)
-            } else path = require('path').join('file://', __dirname, '../', langPage)
-            focusedWindow.loadURL(path)
+            var goToPath
+            var location = focusedWindow.webContents.getURL()
+            var currentPage = location.split('/').pop().replace('.html', '')
+            if (currentPage.indexOf('index') < 0) {
+              if (location.match('/pages/')) return goToPath = location
+              goToPath = require('path').join('file://', __dirname, '../challenges', currentPage + '.html')
+            } else {
+              goToPath = require('path').join('file://', __dirname, '../index.html')
+            }
+            focusedWindow.loadURL(goToPath)
           }
         }
       },
@@ -121,15 +123,19 @@ module.exports = function menu (app, mainWindow) {
         label: '正體中文',
         click: function (item, focusedWindow) {
           if (focusedWindow) {
-            var path = ''
+            var goToPath
             var lang = '-zhtw'
-            var currentPage = focusedWindow.webContents.getURL().split('/').pop().replace('.html', '')
-            if (currentPage.match('zhtw') || currentPage.match('ja')) currentPage = currentPage.split('-')[0]
-            var langPage = currentPage + lang + '.html'
-            if (langPage.indexOf('index') < 0) {
-              path = require('path').join('file://', __dirname, '../challenges', langPage)
-            } else path = require('path').join('file://', __dirname, '../', langPage)
-            focusedWindow.loadURL(path)
+            var location = focusedWindow.webContents.getURL()
+            var currentPage = location.split('/').pop().replace('.html', '')
+            if (currentPage.indexOf('index') < 0) {
+              if (location.match('/pages/')) return goToPath = location
+              var chalPath = '../challenges' + lang
+              goToPath = require('path').join('file://', __dirname, chalPath, currentPage + '.html')
+            } else {
+              var indexPath = '../index' + lang + '.html'
+              goToPath = require('path').join('file://', __dirname, indexPath)
+            }
+            focusedWindow.loadURL(goToPath)
           }
         }
       },
@@ -137,15 +143,19 @@ module.exports = function menu (app, mainWindow) {
         label: '日本語',
         click: function (item, focusedWindow) {
           if (focusedWindow) {
-            var path = ''
+            var goToPath
             var lang = '-ja'
-            var currentPage = focusedWindow.webContents.getURL().split('/').pop().replace('.html', '')
-            if (currentPage.match('zhtw') || currentPage.match('ja')) currentPage = currentPage.split('-')[0]
-            var langPage = currentPage + lang + '.html'
-            if (langPage.indexOf('index') < 0) {
-              path = require('path').join('file://', __dirname, '../challenges', langPage)
-            } else path = require('path').join('file://', __dirname, '../', langPage)
-            focusedWindow.loadURL(path)
+            var location = focusedWindow.webContents.getURL()
+            var currentPage = location.split('/').pop().replace('.html', '')
+            if (currentPage.indexOf('index') < 0) {
+              if (location.match('/pages/')) return goToPath = location
+              var chalPath = '../challenges' + lang
+              goToPath = require('path').join('file://', __dirname, chalPath, currentPage + '.html')
+            } else {
+              var indexPath = '../index' + lang + '.html'
+              goToPath = require('path').join('file://', __dirname, indexPath)
+            }
+            focusedWindow.loadURL(goToPath)
           }
         }
       }

--- a/menus/other-menu.js
+++ b/menus/other-menu.js
@@ -35,66 +35,75 @@ module.exports = function menu (mainWindow) {
       ]
     },
     {
-    label: '&Language',
-    submenu: [
-      {
-        label: 'English',
-        click: function (item, focusedWindow) {
-          if (focusedWindow) {
-            var goToPath
-            var location = focusedWindow.webContents.getURL()
-            var currentPage = location.split('/').pop().replace('.html', '')
-            if (currentPage.indexOf('index') < 0) {
-              if (location.match('/pages/')) return goToPath = location
-              goToPath = require('path').join('file://', __dirname, '../challenges', currentPage + '.html')
-            } else {
-              goToPath = require('path').join('file://', __dirname, '../index.html')
+      label: '&Language',
+      submenu: [
+        {
+          label: 'English',
+          click: function (item, focusedWindow) {
+            if (focusedWindow) {
+              var goToPath
+              var location = focusedWindow.webContents.getURL()
+              var currentPage = location.split('/').pop().replace('.html', '')
+              if (currentPage.indexOf('index') < 0) {
+                if (location.match('/pages/')) {
+                  goToPath = location
+                  return
+                }
+                goToPath = require('path').join('file://', __dirname, '../challenges', currentPage + '.html')
+              } else {
+                goToPath = require('path').join('file://', __dirname, '../index.html')
+              }
+              focusedWindow.loadURL(goToPath)
             }
-            focusedWindow.loadURL(goToPath)
+          }
+        },
+        {
+          label: '正體中文',
+          click: function (item, focusedWindow) {
+            if (focusedWindow) {
+              var goToPath
+              var lang = '-zhtw'
+              var location = focusedWindow.webContents.getURL()
+              var currentPage = location.split('/').pop().replace('.html', '')
+              if (currentPage.indexOf('index') < 0) {
+                if (location.match('/pages/')) {
+                  goToPath = location
+                  return
+                }
+                var chalPath = '../challenges' + lang
+                goToPath = require('path').join('file://', __dirname, chalPath, currentPage + '.html')
+              } else {
+                var indexPath = '../index' + lang + '.html'
+                goToPath = require('path').join('file://', __dirname, indexPath)
+              }
+              focusedWindow.loadURL(goToPath)
+            }
+          }
+        },
+        {
+          label: '日本語',
+          click: function (item, focusedWindow) {
+            if (focusedWindow) {
+              var goToPath
+              var lang = '-ja'
+              var location = focusedWindow.webContents.getURL()
+              var currentPage = location.split('/').pop().replace('.html', '')
+              if (currentPage.indexOf('index') < 0) {
+                if (location.match('/pages/')) {
+                  goToPath = location
+                  return
+                }
+                var chalPath = '../challenges' + lang
+                goToPath = require('path').join('file://', __dirname, chalPath, currentPage + '.html')
+              } else {
+                var indexPath = '../index' + lang + '.html'
+                goToPath = require('path').join('file://', __dirname, indexPath)
+              }
+              focusedWindow.loadURL(goToPath)
+            }
           }
         }
-      },
-      {
-        label: '正體中文',
-        click: function (item, focusedWindow) {
-          if (focusedWindow) {
-            var goToPath
-            var lang = '-zhtw'
-            var location = focusedWindow.webContents.getURL()
-            var currentPage = location.split('/').pop().replace('.html', '')
-            if (currentPage.indexOf('index') < 0) {
-              if (location.match('/pages/')) return goToPath = location
-              var chalPath = '../challenges' + lang
-              goToPath = require('path').join('file://', __dirname, chalPath, currentPage + '.html')
-            } else {
-              var indexPath = '../index' + lang + '.html'
-              goToPath = require('path').join('file://', __dirname, indexPath)
-            }
-            focusedWindow.loadURL(goToPath)
-          }
-        }
-      },
-      {
-        label: '日本語',
-        click: function (item, focusedWindow) {
-          if (focusedWindow) {
-            var goToPath
-            var lang = '-ja'
-            var location = focusedWindow.webContents.getURL()
-            var currentPage = location.split('/').pop().replace('.html', '')
-            if (currentPage.indexOf('index') < 0) {
-              if (location.match('/pages/')) return goToPath = location
-              var chalPath = '../challenges' + lang
-              goToPath = require('path').join('file://', __dirname, chalPath, currentPage + '.html')
-            } else {
-              var indexPath = '../index' + lang + '.html'
-              goToPath = require('path').join('file://', __dirname, indexPath)
-            }
-            focusedWindow.loadURL(goToPath)
-          }
-        }
-      }
-    ]
+      ]
     },
     {
       label: '&Resources',
@@ -102,7 +111,7 @@ module.exports = function menu (mainWindow) {
         {
           label: 'Home',
           click: function (item, focusedWindow) {
-            if (focusedWindow)
+            if (focusedWindow) {
               var lang, regexp
               var location = focusedWindow.webContents.getURL()
               var currentPage = location.split('/').pop().replace('.html', '')
@@ -112,35 +121,39 @@ module.exports = function menu (mainWindow) {
               var page = '../index' + lang + '.html'
               var path = require('path').join('file://', __dirname, page)
               focusedWindow.loadURL(path)
+            }
           }
         },
         {
           label: 'Dictionary',
           click: function (item, focusedWindow) {
-            if (focusedWindow)
+            if (focusedWindow) {
               var path = require('path').join('file://', __dirname, '../pages/dictionary.html')
               focusedWindow.loadURL(path)
+            }
           }
         },
         {
           label: 'Resources',
           click: function (item, focusedWindow) {
-            if (focusedWindow)
+            if (focusedWindow) {
               var path = require('path').join('file://', __dirname, '../pages/resources.html')
               focusedWindow.loadURL(path)
+            }
           }
         },
         {
           label: 'About App',
           click: function (item, focusedWindow) {
-            if (focusedWindow)
+            if (focusedWindow) {
               var path = require('path').join('file://', __dirname, '../pages/about.html')
               focusedWindow.loadURL(path)
+            }
           }
         },
         {
           label: 'Open Issue',
-          click: function() { require('electron').shell.openExternal('https://github.com/jlord/git-it-electron/issues/new') }
+          click: function () { require('electron').shell.openExternal('https://github.com/jlord/git-it-electron/issues/new') }
         }
       ]
     },

--- a/menus/other-menu.js
+++ b/menus/other-menu.js
@@ -35,6 +35,116 @@ module.exports = function menu (mainWindow) {
       ]
     },
     {
+    label: '&Language',
+    submenu: [
+      {
+        label: 'English',
+        click: function (item, focusedWindow) {
+          if (focusedWindow) {
+            var goToPath
+            var location = focusedWindow.webContents.getURL()
+            var currentPage = location.split('/').pop().replace('.html', '')
+            if (currentPage.indexOf('index') < 0) {
+              if (location.match('/pages/')) return goToPath = location
+              goToPath = require('path').join('file://', __dirname, '../challenges', currentPage + '.html')
+            } else {
+              goToPath = require('path').join('file://', __dirname, '../index.html')
+            }
+            focusedWindow.loadURL(goToPath)
+          }
+        }
+      },
+      {
+        label: '正體中文',
+        click: function (item, focusedWindow) {
+          if (focusedWindow) {
+            var goToPath
+            var lang = '-zhtw'
+            var location = focusedWindow.webContents.getURL()
+            var currentPage = location.split('/').pop().replace('.html', '')
+            if (currentPage.indexOf('index') < 0) {
+              if (location.match('/pages/')) return goToPath = location
+              var chalPath = '../challenges' + lang
+              goToPath = require('path').join('file://', __dirname, chalPath, currentPage + '.html')
+            } else {
+              var indexPath = '../index' + lang + '.html'
+              goToPath = require('path').join('file://', __dirname, indexPath)
+            }
+            focusedWindow.loadURL(goToPath)
+          }
+        }
+      },
+      {
+        label: '日本語',
+        click: function (item, focusedWindow) {
+          if (focusedWindow) {
+            var goToPath
+            var lang = '-ja'
+            var location = focusedWindow.webContents.getURL()
+            var currentPage = location.split('/').pop().replace('.html', '')
+            if (currentPage.indexOf('index') < 0) {
+              if (location.match('/pages/')) return goToPath = location
+              var chalPath = '../challenges' + lang
+              goToPath = require('path').join('file://', __dirname, chalPath, currentPage + '.html')
+            } else {
+              var indexPath = '../index' + lang + '.html'
+              goToPath = require('path').join('file://', __dirname, indexPath)
+            }
+            focusedWindow.loadURL(goToPath)
+          }
+        }
+      }
+    ]
+    },
+    {
+      label: '&Resources',
+      submenu: [
+        {
+          label: 'Home',
+          click: function (item, focusedWindow) {
+            if (focusedWindow)
+              var lang, regexp
+              var location = focusedWindow.webContents.getURL()
+              var currentPage = location.split('/').pop().replace('.html', '')
+              if (currentPage.match('index')) regexp = /index(-\w+).html/
+              else regexp = /challenges(-\w+)\//
+              lang = location.match(regexp) ? '-' + location.match(regexp)[1].substr(1) : ''
+              var page = '../index' + lang + '.html'
+              var path = require('path').join('file://', __dirname, page)
+              focusedWindow.loadURL(path)
+          }
+        },
+        {
+          label: 'Dictionary',
+          click: function (item, focusedWindow) {
+            if (focusedWindow)
+              var path = require('path').join('file://', __dirname, '../pages/dictionary.html')
+              focusedWindow.loadURL(path)
+          }
+        },
+        {
+          label: 'Resources',
+          click: function (item, focusedWindow) {
+            if (focusedWindow)
+              var path = require('path').join('file://', __dirname, '../pages/resources.html')
+              focusedWindow.loadURL(path)
+          }
+        },
+        {
+          label: 'About App',
+          click: function (item, focusedWindow) {
+            if (focusedWindow)
+              var path = require('path').join('file://', __dirname, '../pages/about.html')
+              focusedWindow.loadURL(path)
+          }
+        },
+        {
+          label: 'Open Issue',
+          click: function() { require('electron').shell.openExternal('https://github.com/jlord/git-it-electron/issues/new') }
+        }
+      ]
+    },
+    {
       label: 'Help',
       submenu: [
         {

--- a/pages/about.html
+++ b/pages/about.html
@@ -51,18 +51,6 @@
 
 <p>This app is built with HTML, CSS and JS and uses the <a href="http://electron.atom.io">Electron</a> library. Read more about its development in its documentation (Coming soon!). <a href="http://github.com/jlord/git-it-electron" target="_blank">Git-it repository on GitHub</a>.</p>
 
-      <footer>
-  <ul>
-    <li class="all-caps"><a href="../index.html"><strong>Git-it Challenges</strong></a></li>
-    <li class="all-caps"><a href="about.html">About</a></li>
-    <li class="all-caps"><a href="dictionary.html">Dictionary</a></li>
-    <li class="all-caps"><a href="resources.html">Resources</a></li>
-    <li class="all-caps">
-      <a href="http://github.com/jlord/git-it/issues/new" target="_blank">Open an Issue</a>
-    </li>
-  </ul>
-</footer>
-
     </div>
 
   </body>

--- a/pages/dictionary.html
+++ b/pages/dictionary.html
@@ -147,18 +147,6 @@
   </ul>
 </div>
 
-      <footer>
-  <ul>
-    <li class="all-caps"><a href="../index.html"><strong>Git-it Challenges</strong></a></li>
-    <li class="all-caps"><a href="about.html">About</a></li>
-    <li class="all-caps"><a href="dictionary.html">Dictionary</a></li>
-    <li class="all-caps"><a href="resources.html">Resources</a></li>
-    <li class="all-caps">
-      <a href="http://github.com/jlord/git-it/issues/new" target="_blank">Open an Issue</a>
-    </li>
-  </ul>
-</footer>
-
     </div>
 
   </body>

--- a/pages/resources.html
+++ b/pages/resources.html
@@ -77,18 +77,6 @@ A great presentation that compares Git commands to writing and mailing a letter.
   <li><a href="https://speakerdeck.com/yunico/20140601-github-kaigi-yunico?slide=16">GitHub Kaigi</a> by  Yunico Nagata</li>
 </ul>
 
-      <footer>
-  <ul>
-    <li class="all-caps"><a href="../index.html"><strong>Git-it Challenges</strong></a></li>
-    <li class="all-caps"><a href="about.html">About</a></li>
-    <li class="all-caps"><a href="dictionary.html">Dictionary</a></li>
-    <li class="all-caps"><a href="resources.html">Resources</a></li>
-    <li class="all-caps">
-      <a href="http://github.com/jlord/git-it/issues/new" target="_blank">Open an Issue</a>
-    </li>
-  </ul>
-</footer>
-
     </div>
 
   </body>

--- a/partials/chal-footer.html
+++ b/partials/chal-footer.html
@@ -10,14 +10,3 @@
     </a>
   </div>
 </div>
-<footer>
-  <ul>
-    <li class="all-caps"><a href="../index{{lang}}.html"><strong>Git-it Challenges</strong></a></li>
-    <li class="all-caps"><a href="../pages/about.html">About</a></li>
-    <li class="all-caps"><a href="../pages/dictionary.html">Dictionary</a></li>
-    <li class="all-caps"><a href="../pages/resources.html">Resources</a></li>
-    <li class="all-caps">
-      <a href="http://github.com/jlord/git-it/issues/new" target="_blank">Open an Issue</a>
-    </li>
-  </ul>
-</footer>


### PR DESCRIPTION
This PR adds some things to the app menu—

- Go to about, dictionary, resources, or new issue (external) pages
- Switch between languages (pages :point_up: are only in English)

In an effort to make it less website-y, I've removed the footer from the pages now that the things it liked to  can be accessed from the menu. 