### PR TITLE
Fix html reserved chars and other minor typos

### DIFF
--- a/challenge-content-ja/7_branches_arent_just_for_birds.html
+++ b/challenge-content-ja/7_branches_arent_just_for_birds.html
@@ -67,7 +67,7 @@ GitHub Guide: <a href="http://guides.github.com/overviews/flow/" target="_blank"
 
   <h4>Branch name expected: _____</h4>
   <p>ブランチ名はあなたのユーザー名と完全に一致していないといけません。ブランチ名を変更するには:</p>
-  <p><code>$ git branch -M &#60;NEWBRANCHNAME&#62;</code></p>
+  <p><code>$ git branch -m &#60;NEWBRANCHNAME&#62;</code></p>
   <p>うまくできたら、もう一回 verify してみましょう!</p>
 </div>
 

--- a/challenge-content-zhtw/7_branches_arent_just_for_birds.html
+++ b/challenge-content-zhtw/7_branches_arent_just_for_birds.html
@@ -66,7 +66,7 @@
 
         <h4><n>Branch</n> name expected: _____</h4>
         <p><n>Branch</n> 的名字應該要跟你的帳號名稱一模一樣。用以下的指令修改 <n>branch</n> 的名字：</p>
-        <p><code class="shell">git branch -M &#60;NEWBRANCHNAME&#62;</code></p>
+        <p><code class="shell">git branch -m &#60;NEWBRANCHNAME&#62;</code></p>
         <p>完成以上的動作之後，再執行一次 <code>git-it verify</code>！</p>
       </div>
 

--- a/challenge-content/7_branches_arent_just_for_birds.html
+++ b/challenge-content/7_branches_arent_just_for_birds.html
@@ -72,7 +72,7 @@
 
   <h4>Branch name expected: _____</h4>
   <p>The branch name should match your user name exactly. To change your branch name:</p>
-  <p><code class="shell">git branch -M &#60;NEWBRANCHNAME&#62;</code></p>
+  <p><code class="shell">git branch -m &#60;NEWBRANCHNAME&#62;</code></p>
   <p>When you've made your updates, verify again!</p>
 </div>
 

--- a/challenges/branches_arent_just_for_birds.html
+++ b/challenges/branches_arent_just_for_birds.html
@@ -198,7 +198,7 @@
 
   <h4>Branch name expected: _____</h4>
   <p>The branch name should match your user name exactly. To change your branch name:</p>
-  <p><code class="shell">git branch -M &#60;NEWBRANCHNAME&#62;</code></p>
+  <p><code class="shell">git branch -m &#60;NEWBRANCHNAME&#62;</code></p>
   <p>When you've made your updates, verify again!</p>
 </div>
 

--- a/pages-content/dictionary.html
+++ b/pages-content/dictionary.html
@@ -69,7 +69,7 @@
     <li><strong>Add remote connections</strong></li>
     <code class="shell">git remote add &#60;REMOTENAME&#62; &#60;URL&#62;</code>
     <li><strong>Set a URL to a remote</strong></li>
-    <code class="shell">git remote set-url &#60;REMOTENAME&#62; <URL></code>
+    <code class="shell">git remote set-url &#60;REMOTENAME&#62; &#60;URL&#62;</code>
     <li><strong>View remote connections</strong></li>
     <code class="shell">git remote -v</code>
   </ul>
@@ -79,9 +79,9 @@
 <div class="blue-border-box">
   <ul class="no-list-style">
     <li><strong>Pull in changes</strong></li>
-    <code class="shell">git pull &#60;REMOTENAME&#62; &#60;BRANCHNAME&#62;</code>
+    <code class="shell">git pull</code>
     <li><strong>Pull in changes from a remote branch</strong></li>
-    <code class="shell">git pull <REMOTENAME> <REMOTEBRANCH></code>
+    <code class="shell">git pull &#60;REMOTENAME&#62; &#60;REMOTEBRANCH&#62;</code>
     <li><strong>See changes to the remote before you pull in</strong></li>
     <code class="shell">git fetch --dry-run</code>
   </ul>
@@ -91,7 +91,7 @@
 <div class="blue-border-box">
   <ul class="no-list-style">
     <li><strong>Push changes</strong></li>
-    <code class="shell">git push &#60;REMOTENAME&#62; <BRANCH></code>
+    <code class="shell">git push &#60;REMOTENAME&#62; &#60;BRANCHNAME&#62;</code>
     <li><strong>Merge a branch into current branch</strong></li>
     <code class="shell">git merge &#60;BRANCHNAME&#62;</code>
   </ul>

--- a/pages/dictionary.html
+++ b/pages/dictionary.html
@@ -108,7 +108,7 @@
     <li><strong>Add remote connections</strong></li>
     <code class="shell">git remote add &#60;REMOTENAME&#62; &#60;URL&#62;</code>
     <li><strong>Set a URL to a remote</strong></li>
-    <code class="shell">git remote set-url &#60;REMOTENAME&#62; <URL></code>
+    <code class="shell">git remote set-url &#60;REMOTENAME&#62; &#60;URL&#62;</code>
     <li><strong>View remote connections</strong></li>
     <code class="shell">git remote -v</code>
   </ul>
@@ -118,9 +118,9 @@
 <div class="blue-border-box">
   <ul class="no-list-style">
     <li><strong>Pull in changes</strong></li>
-    <code class="shell">git pull &#60;REMOTENAME&#62; &#60;BRANCHNAME&#62;</code>
+    <code class="shell">git pull</code>
     <li><strong>Pull in changes from a remote branch</strong></li>
-    <code class="shell">git pull <REMOTENAME> <REMOTEBRANCH></code>
+    <code class="shell">git pull &#60;REMOTENAME&#62; &#60;REMOTEBRANCH&#62;</code>
     <li><strong>See changes to the remote before you pull in</strong></li>
     <code class="shell">git fetch --dry-run</code>
   </ul>
@@ -130,7 +130,7 @@
 <div class="blue-border-box">
   <ul class="no-list-style">
     <li><strong>Push changes</strong></li>
-    <code class="shell">git push &#60;REMOTENAME&#62; <BRANCH></code>
+    <code class="shell">git push &#60;REMOTENAME&#62; &#60;BRANCHNAME&#62;</code>
     <li><strong>Merge a branch into current branch</strong></li>
     <code class="shell">git merge &#60;BRANCHNAME&#62;</code>
   </ul>


### PR DESCRIPTION
... as done for git-it, see jlord/git-it#227.

> In guide html pages, the text of some git command parameters disappear when rendered in browser because reserved chars aren't escaped as char references.