### PR TITLE
Ignoring /out/ instead of out to ignore only out folder

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,9 +21,9 @@
     "build-zhtw": "node lib/build-challenges.js zhtw",
     "build-ja": "node lib/build-challenges.js ja",
     "build-all": "npm run build-chals && npm run build-pages && npm run build-zhtw && npm run build-ja",
-    "pack-mac": "electron-packager . Git-it --platform=darwin --arch=x64   --icon=assets/git-it.icns --overwrite --ignore=out --ignore=assets/PortableGit --prune=true --out=out",
-    "pack-lin": "electron-packager . Git-it --platform=linux  --arch=x64   --icon=assets/git-it.png  --overwrite --ignore=out --ignore=assets/PortableGit --prune=true --out=out",
-    "pack-win": "electron-packager . Git-it --platform=win32  --arch=ia32  --icon=assets/git-it.ico  --overwrite --ignore=out --prune=true --out=out "
+    "pack-mac": "electron-packager . Git-it --platform=darwin --arch=x64   --icon=assets/git-it.icns --overwrite --ignore=/out/ --ignore=assets/PortableGit --prune=true --out=out",
+    "pack-lin": "electron-packager . Git-it --platform=linux  --arch=x64   --icon=assets/git-it.png  --overwrite --ignore=/out/ --ignore=assets/PortableGit --prune=true --out=out",
+    "pack-win": "electron-packager . Git-it --platform=win32  --arch=ia32  --icon=assets/git-it.ico  --overwrite --ignore=/out/ --prune=true --out=out "
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Today @ogom alerted me at NodeSchool that the deployed version is missing Section 9 "9_pull_never_out_of_date.html". It does so because the scripts to package the application specifies `--ignore=out` where "out" stands for `new RegExp("out")` on the file path and effectively filters out also the `...ver_out_of...` part of this the sections file name! This PR replaces the section with a `/out/` that will include the section again.

_Note: I also opened [node-fs-extra#239](https://github.com/jprichardson/node-fs-extra/issues/239) in order to get a better API for the electron packager._