### PR TITLE
Remember directory in use

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,4 @@ build/Release
 node_modules
 
 # Packaged Builds
-Git-it-win32*/
-Git-it-darwin*/
-Git-it-linux*/
+out/

--- a/assets/css/new-challenge.css
+++ b/assets/css/new-challenge.css
@@ -146,6 +146,10 @@ gre7-border.border-box code {
    display: none;
  }
 
+ #directory-path:before {
+   content: 'Verifying: ';
+ }
+
  #path-required-warning,
  #directory-path {
    padding: 6px 12px 6px 10px;

--- a/empty-saved-dir.json
+++ b/empty-saved-dir.json
@@ -1,0 +1,3 @@
+{
+  "savedDir": null
+}

--- a/lib/challenge.js
+++ b/lib/challenge.js
@@ -26,7 +26,7 @@ if (selectDirBtn) {
 
 var currentDirectory = userData.getSavedDir().contents.savedDir
 var challengeCompleted = userData.getData().contents
-if (currentDirectory && !challengeCompleted[currentChallenge].completed) {
+if (selectDirBtn && currentDirectory && !challengeCompleted[currentChallenge].completed) {
   selectDirectory(currentDirectory)
 }
 

--- a/lib/challenge.js
+++ b/lib/challenge.js
@@ -31,6 +31,7 @@ if (currentChallenge === 'forks_and_clones') {
   userData.updateCurrentDirectory(null)
 } else if (selectDirBtn && currentDirectory && !challengeCompleted[currentChallenge].completed) {
   selectDirectory(currentDirectory)
+  selectDirBtn.innerHTML = 'CHANGE DIRECTORY'
 }
 
 // Handle verify challenge click

--- a/lib/challenge.js
+++ b/lib/challenge.js
@@ -5,6 +5,7 @@
 var userData = require('./user-data')
 
 var selectDirBtn = document.getElementById('select-directory')
+var currentChallenge = window.currentChallenge
 
 var selectDirectory = function (path) {
   document.getElementById('path-required-warning').classList.remove('show')
@@ -31,7 +32,6 @@ if (currentDirectory && !challengeCompleted[currentChallenge].completed) {
 
 // Handle verify challenge click
 document.getElementById('verify-challenge').addEventListener('click', function clicked (event) {
-  var currentChallenge = window.currentChallenge
   var verifyChallenge = require('../lib/verify/' + currentChallenge + '.js')
 
   // If a directory is needed

--- a/lib/challenge.js
+++ b/lib/challenge.js
@@ -23,8 +23,9 @@ if (selectDirBtn) {
   })
 }
 
-var currentDirectory = userData.getData().contents.currentDirectory
-if (currentDirectory) {
+var currentDirectory = userData.getSavedDir().contents.savedDir
+var challengeCompleted = userData.getData().contents
+if (currentDirectory && !challengeCompleted[currentChallenge].completed) {
   selectDirectory(currentDirectory)
 }
 

--- a/lib/challenge.js
+++ b/lib/challenge.js
@@ -26,7 +26,10 @@ if (selectDirBtn) {
 
 var currentDirectory = userData.getSavedDir().contents.savedDir
 var challengeCompleted = userData.getData().contents
-if (selectDirBtn && currentDirectory && !challengeCompleted[currentChallenge].completed) {
+if (currentChallenge === 'forks_and_clones') {
+  // on this challenge clear out the saved dir because it should change
+  userData.updateCurrentDirectory(null)
+} else if (selectDirBtn && currentDirectory && !challengeCompleted[currentChallenge].completed) {
   selectDirectory(currentDirectory)
 }
 

--- a/lib/user-data.js
+++ b/lib/user-data.js
@@ -12,6 +12,14 @@ var getData = function () {
   data.contents = JSON.parse(fs.readFileSync(data.path))
   return data
 }
+
+var getSavedDir = function () {
+  var savedDir = {}
+  data.path = ipc.sendSync('getUserSavedDir', null)
+  data.contents = JSON.parse(fs.readFileSync(data.path))
+  return savedDir
+}
+
 var writeData = function (data) {
   fs.writeFile(data.path, JSON.stringify(data.contents, null, ' '), function updatedUserData (err) {
     if (err) return console.log(err)
@@ -27,8 +35,8 @@ var updateData = function (challenge) {
   writeData(data)
 }
 var updateCurrentDirectory = function (path) {
-  var data = getData()
-  data.contents.currentDirectory = path
+  var data = getSavedDir()
+  data.contents.savedDir = path
 
   writeData(data)
 }

--- a/lib/user-data.js
+++ b/lib/user-data.js
@@ -15,8 +15,8 @@ var getData = function () {
 
 var getSavedDir = function () {
   var savedDir = {}
-  data.path = ipc.sendSync('getUserSavedDir', null)
-  data.contents = JSON.parse(fs.readFileSync(data.path))
+  savedDir.path = ipc.sendSync('getUserSavedDir', null)
+  savedDir.contents = JSON.parse(fs.readFileSync(savedDir.path))
   return savedDir
 }
 
@@ -42,5 +42,6 @@ var updateCurrentDirectory = function (path) {
 }
 
 module.exports.getData = getData
+module.exports.getSavedDir = getSavedDir
 module.exports.updateData = updateData
 module.exports.updateCurrentDirectory = updateCurrentDirectory

--- a/main.js
+++ b/main.js
@@ -48,7 +48,7 @@ app.on('ready', function appReady () {
 
   fs.exists(userSavedDir, function (exists) {
     if (!exists) {
-      fs.writeFile(userSavedDir, JSON.stringify(emptyData, null, ' '), function (err) {
+      fs.writeFile(userSavedDir, JSON.stringify(emptySavedDir, null, ' '), function (err) {
         if (err) return console.log(err)
       })
     }

--- a/main.js
+++ b/main.js
@@ -10,6 +10,7 @@ var darwinTemplate = require('./menus/darwin-menu.js')
 var otherTemplate = require('./menus/other-menu.js')
 
 var emptyData = require('./empty-data.json')
+var emptySavedDir = require('./empty-saved-dir.json')
 
 var mainWindow = null
 var menu = null
@@ -25,7 +26,9 @@ app.on('window-all-closed', function appQuit () {
 app.on('ready', function appReady () {
   mainWindow = new BrowserWindow({"minWidth": 800, "minHeight": 600, width: 980, height: 760, title: 'Git-it', icon: iconPath })
 
-  var userDataPath = path.join(app.getPath('userData'), 'user-data.json')
+  var appPath = app.getPath('userData')
+  var userDataPath = path.join(appPath, 'user-data.json')
+  var userSavedDir = path.join(appPath, 'saved-dir.json')
 
   // tools for development to prefill challenge completion
   // usage: electron . --none
@@ -43,10 +46,22 @@ app.on('ready', function appReady () {
     }
   })
 
+  fs.exists(userSavedDir, function (exists) {
+    if (!exists) {
+      fs.writeFile(userSavedDir, JSON.stringify(emptyData, null, ' '), function (err) {
+        if (err) return console.log(err)
+      })
+    }
+  })
+
   mainWindow.loadURL('file://' + __dirname + '/index.html')
 
   ipc.on('getUserDataPath', function (event) {
     event.returnValue = userDataPath
+  })
+
+  ipc.on('getUserSavedDir', function (event) {
+    event.returnValue = userSavedDir
   })
 
   ipc.on('open-file-dialog', function (event) {


### PR DESCRIPTION
This pull requests supersedes #124—fixing a couple things and then adding some things so that the flow of this feature is a bit nicer.

This enables Git-it to remember what directory you've selected so that you don't have to select it for every challenge.

Here are the other things this pull request takes care of in implementing this:

- Fix from #124: Create a new data file so that errors aren't caused when other parts of Git-it assume every item in `user-data` is a challenge.
- Fix from #124: Only show saved dir on challenges that require a directory (otherwise there is an error)
- Don't show the directory when a completed challenge is loaded (to keep things simple, clean)
- Show "Verifying:" in front of the path so when a new challenge is loaded and there is a path there it is a little more clear what that path is there for.
- Change the button to say "Change Directory" when challenge is using a saved directory.
- Clear the saved directory once the user gets to the Forks and Clones challenge where they should be using a different repository.

<img width="737" alt="screen shot 2016-05-13 at 8 55 45 pm" src="https://cloud.githubusercontent.com/assets/1305617/15261595/200627e6-194d-11e6-8524-c07caf99240a.png">

Unrelated it also `.gitignore`s the output build directory 🍕 

Closes #47 
