### PR TITLE
Translate English text at the introduction of `index-ja.html` into Japanese

### DIFF
--- a/index-ja.html
+++ b/index-ja.html
@@ -27,15 +27,15 @@
 
     <div class="page-wrapper">
       <h2>Git-itにようこそ!</h2>
-      <p>Step-by-step instructions for each of the challenges in the <a href="http://github.com/jlord/git-it" target="_blank">Git-it workshop</a>.</p>
-      <p>This guide comes with Git-it when you install it so it works offline and you can use it as a resource at anytime (see the instructions when you select a challenge in terminal). Have fun!</p>
+      <p><a href="http://github.com/jlord/git-it" target="_blank">Git-it workshop</a> チャレンジの各ステップの説明です。</p>
+      <p>Git-itをインストールすればオフラインでも教材として利用できます（ターミナルでチャレンジするときはターミナルの説明を見てください）。楽しんでください!</p>
 
       <a href="challenges-ja/get_git.html" id="get-started"><button class="teal full-width">Get Started!</button></a>
 
       <h2>Git-it チャレンジ</h2>
 
       <ol class="toc">
-        <li id="get_git"><a href="challenges-ja/get_git.html">Get Git</a>Gitをインストールして設定をする</li>
+        <li id="get_git"><a href="challenges-ja/get_git.html">Get Git</a> Gitをインストールして設定をする</li>
         <li id='repository'><a href="challenges-ja/repository.html">Repository
         </a> ローカルのrepositoryを作成</li>
         <li id='commit_to_it'><a href="challenges-ja/commit_to_it.html">Commit to it</a> ステータスを確認して、コンテンツを追加してcommitをする</li>


### PR DESCRIPTION
Translated English text at the introduction of `index-ja.html` into Japanese.

If this pull request is merged, it makes us happy.
Because we will use it at **[GitHub Patchwork in Akashi](https://codeforkosen.doorkeeper.jp/events/48329)**, Japan today :)