### PR TITLE
Update Fork and Branches challenges

### DIFF
--- a/challenge-content/6_forks_and_clones.html
+++ b/challenge-content/6_forks_and_clones.html
@@ -46,15 +46,17 @@
 
   <p><code class="shell">git remote add upstream https://github.com/jlord/patchwork.git</code></p>
 
-  <p>To be sure you have the correct remotes set up, type <code>git remote -v</code> to list out the addresses you have stored. You should have an 'origin' remote with <em>your fork's</em> address and then an 'upstream' remote with the address to the original, with the URL noted above in this step.</p>
+  <p>To be sure you have the correct remotes set up, type <code>git remote -v</code> to list out the addresses you have stored. <b>You should have an 'origin' remote with your fork's address and then an 'upstream' remote with the address to the original, the URL noted above in this step.</b></p>
 </div>
 
 {{{ verify_directory_button }}}
 
 <div class="chal-tip grey-border border-box">
   <ul class="no-list-style">
-    <li><strong>Add remote connections</strong></li>
+    <li><strong>Add a remote</strong></li>
     <li><code class="shell">git remote add &#60;REMOTENAME&#62; &#60;URL&#62;</code></li>
+    <li><strong>Change a remote URL</strong></li>
+    <li><code class="shell">git remote set-url &#60;REMOTENAME&#62; &#60;URL&#62;</code></li>
     <li><strong>View remote connections</strong></li>
     <li><code class="shell">git remote -v</code></li>
   </ul>

--- a/challenge-content/7_branches_arent_just_for_birds.html
+++ b/challenge-content/7_branches_arent_just_for_birds.html
@@ -54,15 +54,18 @@
   <p><code class="shell">git add &#60;FILENAME&#62;</code></p>
   <p><code class="shell">git commit -m "commit message"</code></p>
 
-  <p>Now push your update to your fork on GitHub:</p>
+  <p>Now push your update to <b>your fork</b>, 'origin', on GitHub:</p>
   <p><code class="shell">git push origin &#60;BRANCHNAME&#62;</code></p>
-
-  <p>Make sure that you're pushing to 'origin', which is your fork's address on GitHub. If you get an error check to make sure you have your remotes set up correctly with 'origin' pointing to your fork and 'upstream' pointing to the original repository: <code>git remote -v</code>
 </div>
 
 {{{ verify_directory_button }}}
 
 <div class="chal-no-pass grey-border border-box">
+  <h4>Permission denied...error: 403</h4>
+  <p>You are pushing changes to a repository you don't have write access to. In this case, you're likely pushing ot the original 'jlord/patchwork'. Make sure that you're pushing to 'origin' and that it points to your fork's address on GitHub. To check and see what your remotes are and where they point run <code>git remote -v</code>. You should have 'upstream' pointing to 'jlord/patchwork' and 'origin' pointing to 'yourusername/patchwork'.
+
+  <p>To fix a remote that is pointing to the wrong place you can re-set its url: <code>git remote set-url origin <URLTOYOURFORK></code>.
+
   <h4>File NOT in contributors folder</h4>
   <p>The file you create should be placed inside the existing 'contributors' folder in the Patchwork repository. If you put it somewhere else, simply use Finder or Windows Explorer to move your file into the folder. You can check <code>git status</code> again and you'll find it sees your changes. Stage and then commit "all" (-A) of these changes (additions and deletions) with the commands below.</p>
   <p><code class="shell">git add -A</code></p>

--- a/challenges/branches_arent_just_for_birds.html
+++ b/challenges/branches_arent_just_for_birds.html
@@ -168,10 +168,8 @@
   <p><code class="shell">git add &#60;FILENAME&#62;</code></p>
   <p><code class="shell">git commit -m "commit message"</code></p>
 
-  <p>Now push your update to your fork on GitHub:</p>
+  <p>Now push your update to <b>your fork</b>, 'origin', on GitHub:</p>
   <p><code class="shell">git push origin &#60;BRANCHNAME&#62;</code></p>
-
-  <p>Make sure that you're pushing to 'origin', which is your fork's address on GitHub. If you get an error check to make sure you have your remotes set up correctly with 'origin' pointing to your fork and 'upstream' pointing to the original repository: <code>git remote -v</code>
 </div>
 
 <div class="verify bold-blue solid-box">
@@ -189,6 +187,11 @@
 </div>
 
 <div class="chal-no-pass grey-border border-box">
+  <h4>Permission denied...error: 403</h4>
+  <p>You are pushing changes to a repository you don't have write access to. In this case, you're likely pushing ot the original 'jlord/patchwork'. Make sure that you're pushing to 'origin' and that it points to your fork's address on GitHub. To check and see what your remotes are and where they point run <code>git remote -v</code>. You should have 'upstream' pointing to 'jlord/patchwork' and 'origin' pointing to 'yourusername/patchwork'.
+
+  <p>To fix a remote that is pointing to the wrong place you can re-set its url: <code>git remote set-url origin <URLTOYOURFORK></code>.
+
   <h4>File NOT in contributors folder</h4>
   <p>The file you create should be placed inside the existing 'contributors' folder in the Patchwork repository. If you put it somewhere else, simply use Finder or Windows Explorer to move your file into the folder. You can check <code>git status</code> again and you'll find it sees your changes. Stage and then commit "all" (-A) of these changes (additions and deletions) with the commands below.</p>
   <p><code class="shell">git add -A</code></p>

--- a/challenges/forks_and_clones.html
+++ b/challenges/forks_and_clones.html
@@ -160,7 +160,7 @@
 
   <p><code class="shell">git remote add upstream https://github.com/jlord/patchwork.git</code></p>
 
-  <p>To be sure you have the correct remotes set up, type <code>git remote -v</code> to list out the addresses you have stored. You should have an 'origin' remote with <em>your fork's</em> address and then an 'upstream' remote with the address to the original, with the URL noted above in this step.</p>
+  <p>To be sure you have the correct remotes set up, type <code>git remote -v</code> to list out the addresses you have stored. <b>You should have an 'origin' remote with your fork's address and then an 'upstream' remote with the address to the original, the URL noted above in this step.</b></p>
 </div>
 
 <div class="verify bold-blue solid-box">
@@ -179,8 +179,10 @@
 
 <div class="chal-tip grey-border border-box">
   <ul class="no-list-style">
-    <li><strong>Add remote connections</strong></li>
+    <li><strong>Add a remote</strong></li>
     <li><code class="shell">git remote add &#60;REMOTENAME&#62; &#60;URL&#62;</code></li>
+    <li><strong>Change a remote URL</strong></li>
+    <li><code class="shell">git remote set-url &#60;REMOTENAME&#62; &#60;URL&#62;</code></li>
     <li><strong>View remote connections</strong></li>
     <li><code class="shell">git remote -v</code></li>
   </ul>

--- a/lib/verify/forks_and_clones.js
+++ b/lib/verify/forks_and_clones.js
@@ -7,9 +7,9 @@ var helper = require('../helpers.js')
 var userData = require('../user-data.js')
 
 var addToList = helper.addToList
-var markChallengeCompleted = helper.markChallengeCompleted
 
 var currentChallenge = 'forks_and_clones'
+var username = ''
 
 // check that they've added the remote, that shows
 // that they've also then forked and cloned.
@@ -19,20 +19,53 @@ module.exports = function verifyForksAndClonesChallenge (path) {
     addToList('Path is not a directory', false)
     return helper.challengeIncomplete()
   }
-  exec('remote -v', {cwd: path}, function (err, stdout, stdrr) {
+
+  exec('config user.username', function (err, stdout, stderr) {
     if (err) {
       addToList('Error: ' + err.message, false)
       return helper.challengeIncomplete()
     }
-    var show = stdout.trim()
+    username = stdout.trim()
 
-    if (show.match('upstream') && show.match('github.com[\:\/]jlord/')) {
-      addToList('Upstream remote set up!', true)
-      markChallengeCompleted(currentChallenge)
-      userData.updateData(currentChallenge)
-    } else {
-      addToList('No upstream remote matching /jlord/Patchwork.', false)
-      helper.challengeIncomplete()
-    }
+    exec('remote -v', {cwd: path}, function (err, stdout, stdrr) {
+      if (err) {
+        addToList('Error: ' + err.message, false)
+        return helper.challengeIncomplete()
+      }
+      var remotes = stdout.trim().split('\n')
+      if (remotes.length != 4) {
+        addToList('Not finding 2 remotes set up.', false)
+        helper.challengeIncomplete()
+        userData.updateData(currentChallenge)
+        return
+      }
+      // TODO this is getting wild
+      remotes.splice(1, 2)
+      var incomplete = 0
+
+      remotes.forEach(function (remote) {
+        if (remote.match('origin')) {
+          if (remote.match('github.com[\:\/]' + username + '/')) {
+            addToList('Origin points to your fork!', true)
+          } else {
+            incomplete++
+            addToList('Origin remote not pointing to ' + username + '/patchwork', false)
+
+          }
+        }
+        if (remote.match('upstream')) {
+          if (remote.match('github.com[\:\/]jlord/')) {
+            addToList('Upstream remote set up!', true)
+          } else {
+            incomplete++
+            addToList('Upstream remote not pointing to jlord/patchwork', false)
+          }
+        }
+      })
+      if (incomplete === 0) {
+        userData.updateData(currentChallenge)
+        helper.markChallengeCompleted(currentChallenge)
+      } else helper.challengeIncomplete()
+    })
   })
 }


### PR DESCRIPTION
These two challenges are some of the ones people have the most trouble with. This PR updates the text to hopefully be more clear and it updates the verify step in the Forks challenge to explicitly check that the user has set up their `origin` remote to point to their fork.

Closes https://github.com/jlord/git-it-electron/issues/143
Closes https://github.com/jlord/git-it-electron/issues/133
Closes https://github.com/jlord/patchwork/issues/11600