### PR TITLE
Add path to contributors/FILENAME to avoid error

### DIFF
--- a/challenge-content/7_branches_arent_just_for_birds.html
+++ b/challenge-content/7_branches_arent_just_for_birds.html
@@ -51,7 +51,7 @@
   <p>Go through the steps for checking in a project: </p>
 
   <p><code class="shell">git status</code></p>
-  <p><code class="shell">git add &#60;FILENAME&#62;</code></p>
+  <p><code class="shell">git add &#60;contributors/FILENAME&#62;</code></p>
   <p><code class="shell">git commit -m "commit message"</code></p>
 
   <p>Now push your update to <b>your fork</b>, 'origin', on GitHub:</p>


### PR DESCRIPTION
Because we're still in the `patchwork` directory at this point (but our new file is in the `contributors` directory), when we try to just add the file, we get this error:

`fatal: pathspec 'add-ElizabethN.txt' did not match any files`

To avoid this error, we could either jump to the `contributors` directory or just add it to the filename as such:

`git add contributors/FILENAME.txt`

But it might be a little confusing for some people why the file can't be found.