### PR TITLE
lint the right folder

### DIFF
--- a/menus/darwin-menu.js
+++ b/menus/darwin-menu.js
@@ -118,7 +118,7 @@ module.exports = function menu (app, mainWindow) {
               focusedWindow.loadURL(path)
             }
           }
-        },
+        }
       ]
     },
     {

--- a/menus/other-menu.js
+++ b/menus/other-menu.js
@@ -55,7 +55,7 @@ module.exports = function menu (app, mainWindow) {
           click: function (item, focusedWindow) {
             focusedWindow.webContents.toggleDevTools()
           }
-        },
+        }
       ]
     },
     {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "main": "main.js",
   "scripts": {
     "start": "electron .",
-    "test": "standard lib/*.js lib/verify/*.js menu/*.js main.js",
+    "test": "standard lib/*.js lib/verify/*.js menus/*.js main.js",
     "clean": "rm -Rf built/*",
     "build-chals": "node lib/build-challenges.js",
     "build-pages": "node lib/build-pages.js",


### PR DESCRIPTION
There is no `menu` folder at the root, but `menus` does exists.

So let's point `standard` at that and fix up what it finds.