### PR TITLE
use rimraf for cleaning the built artifacts

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "scripts": {
     "start": "electron .",
     "test": "standard lib/*.js lib/verify/*.js menus/*.js main.js",
-    "clean": "rm -Rf built/*",
+    "clean": "rimraf built/*",
     "build-chals": "node lib/build-challenges.js",
     "build-pages": "node lib/build-pages.js",
     "build-all": "npm run clean && npm run build-chals && npm run build-pages",
@@ -37,6 +37,7 @@
   "devDependencies": {
     "electron": "^1.4.3",
     "electron-packager": "^8.0.0",
+    "rimraf": "^2.5.4",
     "standard": "^5.4.1"
   },
   "dependencies": {


### PR DESCRIPTION
In case you're trying to clean in a different shell environment (like PowerShell) where `rm -Rf` won't behave as advertised... 