### PR TITLE
update travis configuration to cache and use a later version of node

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,10 @@
 language: node_js
+
 node_js:
-  - '0.12'
+  - '6'
+
+cache:
+  timeout: 600
+  directories:
+    - node_modules
+    - $HOME/.electron


### PR DESCRIPTION
I'm not sure how much you care about backwards compatibility, but this should reduce the amount of noise when running CI.

For example, have a peek at `npm install` in [this build](https://travis-ci.org/jlord/git-it-electron/builds/188998519#L146).