### PR TITLE
Add content.lang for function buildHeader in build-pages.js

### DIFF
--- a/lib/build-pages.js
+++ b/lib/build-pages.js
@@ -59,7 +59,8 @@ function buildHeader (filename, lang) {
   var template = Handlebars.compile(source)
   var contents = {
     pageTitle: filename.replace(/.html/, ''),
-    localemenu: new Handlebars.SafeString(locale.getLocaleMenu(lang))
+    localemenu: new Handlebars.SafeString(locale.getLocaleMenu(lang)),
+    lang: lang
   }
   return template(contents)
 }


### PR DESCRIPTION
`function buildHeader (filename, lang) {
  var source = fs.readFileSync(getPartial('header', lang)).toString()
  var template = Handlebars.compile(source)
  var contents = {
    pageTitle: filename.replace(/.html/, ''),
    localemenu: new Handlebars.SafeString(locale.getLocaleMenu(lang))
  }
  return template(contents)
}`

Because there is no 'contents.lang' property in the function 'buildHeader' in build-pages.js, the dictionary.html/about.html/resources.html in 'built' directory have no selected language showed.

Like this
![dict](https://cloud.githubusercontent.com/assets/16317564/22619706/b8124316-eb35-11e6-8d5e-ed84380eb533.png)



**
So I add a 'lang' property for 'contents' object.