### PR TITLE
add flatpak support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ out
 .DS_Store
 built
 .idea
+dist

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,6 +85,11 @@ This will output the contents of the application to a folder at `../out/Git-it-l
 $ npm run pack-win
 ```
 
+This will output the flatpak packaged application to a folder at `../out/Git-it-flatpak-x64`. This requires you to run `npm run pack-lin` first.
+```bash
+$ npm run pack-flatpak
+```
+
 A note from `electron-packager`, the module we use to package these apps:
 
 > **Building Windows apps from non-Windows platforms**

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "build-all": "npm run clean && npm run build-chals && npm run build-pages",
     "pack-mac": "electron-packager . Git-it --platform=darwin --arch=x64   --icon=assets/git-it.icns --overwrite --ignore=/out/ --ignore=assets/PortableGit --ignore=resources --prune=true --out=out",
     "pack-lin": "electron-packager . Git-it --platform=linux  --arch=x64   --icon=assets/git-it.png  --overwrite --ignore=/out/ --ignore=assets/PortableGit --ignore=resources --prune=true --out=out",
-    "pack-win": "electron-packager . Git-it --platform=win32  --arch=ia32  --icon=assets/git-it.ico  --overwrite --ignore=/out/ --ignore=resources --prune=true --out=out "
+    "pack-win": "electron-packager . Git-it --platform=win32  --arch=ia32  --icon=assets/git-it.ico  --overwrite --ignore=/out/ --ignore=resources --prune=true --out=out ",
+    "pack-flatpak": "electron-installer-flatpak --src out/Git-it-linux-x64 --dest out/Git-it-flatpak-x64 --arch x86_64 --config resources/flatpak-config.json"
   },
   "repository": {
     "type": "git",
@@ -36,6 +37,7 @@
   "homepage": "https://github.com/jlord/git-it-electron",
   "devDependencies": {
     "electron": "^1.4.3",
+    "electron-installer-flatpak": "^0.5.0",
     "electron-packager": "^8.0.0",
     "rimraf": "^2.5.4",
     "standard": "^5.4.1"

--- a/resources/flatpak-config.json
+++ b/resources/flatpak-config.json
@@ -1,0 +1,24 @@
+{
+    "bin": "Git-it",
+    "modules": [
+        {
+            "name": "git",
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://github.com/git/git.git",
+                    "branch": "v2.11.0"
+                },
+                {
+                    "type": "shell",
+                    "commands": [
+                        "make configure",
+                        "./configure --prefix=/app/",
+                        "make all",
+                        "make install"
+                    ]
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
This PR adds support for building [flatpak](http://flatpak.org/) for git-it, which should be runnable on any Linux distro. 

### Build and run:
For all requirements have a look at [electron-installer-flatpak](https://github.com/endlessm/electron-installer-flatpak#requirements).

To build this locally call:
```bash
npm run pack-flatpak
```
This gives you with a .flatpak file, which you can then install:
```bash
flatpak install --user --bundle out/Git-it-flatpak-x64/com.github.git-it-electron_master_x86_64.flatpak
flatpak run com.github.git-it-electron
```