### PR TITLE
Make PortableGit to be ignored in language stats

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+assets/PortableGit/* linguist-vendored


### PR DESCRIPTION
Hi! :wave: 

Just saw the "(A Node.js app, not Perl as GH suggests)" and I realised I had this same issue with a repo of mine 😄 

This PR tells [Linguist](https://github.com/github/linguist) to [ignore that folder and all its contents](https://github.com/github/linguist#using-gitattributes) and it looks like this with it:

![image](https://cloud.githubusercontent.com/assets/959128/25439143/ee39c6b2-2a9b-11e7-88cf-0416a4c779e4.png)

(and the current one for fast reference)
![image](https://cloud.githubusercontent.com/assets/959128/25439152/f8d6b922-2a9b-11e7-96b0-d5d859405c2d.png)

It's a really tiny contribution, but just in case it could be useful! 😃

Thanks for the project!! 🤓