### PR TITLE
Fix path on first and last challenge footer links

### DIFF
--- a/lib/build-challenges.js
+++ b/lib/build-challenges.js
@@ -175,7 +175,7 @@ function getPrevious (num, lang) {
     var regexNext = '(^|[^0-9])' + next + '([^0-9]|$)'
     if (pre === 0) {
       prename = 'All Challenges'
-      preurl = path.join('../', 'pages','index.html')
+      preurl = path.join('../', 'pages', 'index.html')
     } else if (file.match(regexPre)) {
       prename = makeTitleName(file, lang)
       var getridof = pre + '_'

--- a/lib/build-challenges.js
+++ b/lib/build-challenges.js
@@ -175,7 +175,7 @@ function getPrevious (num, lang) {
     var regexNext = '(^|[^0-9])' + next + '([^0-9]|$)'
     if (pre === 0) {
       prename = 'All Challenges'
-      preurl = path.join(locale.getLocaleBuiltPath(lang), 'pages/', 'index.html')
+      preurl = path.join('../', 'pages','index.html')
     } else if (file.match(regexPre)) {
       prename = makeTitleName(file, lang)
       var getridof = pre + '_'
@@ -183,7 +183,7 @@ function getPrevious (num, lang) {
     }
     if (next === 12) {
       nextname = 'Done!'
-      nexturl = path.join(locale.getLocaleBuiltPath(lang), 'pages/', 'index.html')
+      nexturl = path.join('../', 'pages', 'index.html')
     } else if (file.match(regexNext)) {
       nextname = makeTitleName(file, lang)
       getridof = next + '_'

--- a/package.json
+++ b/package.json
@@ -20,9 +20,9 @@
     "build-chals": "node lib/build-challenges.js",
     "build-pages": "node lib/build-pages.js",
     "build-all": "npm run clean && npm run build-chals && npm run build-pages",
-    "pack-mac": "electron-packager . Git-it --platform=darwin --arch=x64   --icon=assets/git-it.icns --overwrite --ignore=/out/ --ignore=assets/PortableGit --ignore=resources --prune=true --out=out",
-    "pack-lin": "electron-packager . Git-it --platform=linux  --arch=x64   --icon=assets/git-it.png  --overwrite --ignore=/out/ --ignore=assets/PortableGit --ignore=resources --prune=true --out=out",
-    "pack-win": "electron-packager . Git-it --platform=win32  --arch=ia32  --icon=assets/git-it.ico  --overwrite --ignore=/out/ --ignore=resources --prune=true --out=out "
+    "pack-mac": "electron-packager . Git-it --platform=darwin --arch=x64   --icon=assets/git-it.icns --overwrite --ignore=/out/ --ignore=assets/PortableGit --ignore=resources/ --prune=true --out=out",
+    "pack-lin": "electron-packager . Git-it --platform=linux  --arch=x64   --icon=assets/git-it.png  --overwrite --ignore=/out/ --ignore=assets/PortableGit --ignore=resources/ --prune=true --out=out",
+    "pack-win": "electron-packager . Git-it --platform=win32  --arch=ia32  --icon=assets/git-it.ico  --overwrite --ignore=/out/ --ignore=resources/ --prune=true --out=out "
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This updates to a relative path on the first and last challenge's footer so that they properly go to the `index` home page ✨ 

![screen shot 2017-10-31 at 5 15 10 pm](https://user-images.githubusercontent.com/1305617/32249339-14ab2a1e-be5f-11e7-9762-9179d3bc70ad.png)

This also adds a `/` to the `ignore` in the build script because it was ignoring both the `resources/` directory and `resources.html` in the `pages` directory 😱 

This fixes #193 #200 #188 #207 