### PR TITLE
Fix broken Menu links

### DIFF
--- a/menus/darwin-menu.js
+++ b/menus/darwin-menu.js
@@ -97,7 +97,7 @@ module.exports = function menu (app, mainWindow) {
           click: function (item, focusedWindow) {
             if (focusedWindow) {
               var path = require('path').join(locale.getLocaleBuiltPath(locale.getCurrentLocale(focusedWindow)), 'pages', 'index.html')
-              focusedWindow.loadURL(path)
+              focusedWindow.loadURL('file://' + path)
             }
           }
         },
@@ -106,7 +106,7 @@ module.exports = function menu (app, mainWindow) {
           click: function (item, focusedWindow) {
             if (focusedWindow) {
               var path = require('path').join(locale.getLocaleBuiltPath(locale.getCurrentLocale(focusedWindow)), 'pages', 'dictionary.html')
-              focusedWindow.loadURL(path)
+              focusedWindow.loadURL('file://' + path)
             }
           }
         },
@@ -115,7 +115,7 @@ module.exports = function menu (app, mainWindow) {
           click: function (item, focusedWindow) {
             if (focusedWindow) {
               var path = require('path').join(locale.getLocaleBuiltPath(locale.getCurrentLocale(focusedWindow)), 'pages', 'resources.html')
-              focusedWindow.loadURL(path)
+              focusedWindow.loadURL('file://' + path)
             }
           }
         }
@@ -141,7 +141,7 @@ module.exports = function menu (app, mainWindow) {
           click: function (item, focusedWindow) {
             if (focusedWindow) {
               var path = require('path').join(locale.getLocaleBuiltPath(locale.getCurrentLocale(focusedWindow)), 'pages', 'about.html')
-              focusedWindow.loadURL(path)
+              focusedWindow.loadURL('file://' + path)
             }
           }
         }


### PR DESCRIPTION
This adds the `file://` to the path that Electron is trying to use to load a new page when users click the options from the drop down menu (so that it actually works!).

<img width="577" alt="screen shot 2017-11-01 at 11 41 52 am" src="https://user-images.githubusercontent.com/1305617/32283045-b1870a52-bef9-11e7-86cc-a3b5d085d4f5.png">

Fixes #189 