### PR TITLE
Corrected typo in 7_branches_arent_just_for_birds.html

### DIFF
--- a/resources/contents/en-US/challenges/7_branches_arent_just_for_birds.html
+++ b/resources/contents/en-US/challenges/7_branches_arent_just_for_birds.html
@@ -80,7 +80,7 @@
 
 <div class="chal-no-pass grey-border border-box">
     <h4>Permission denied...error: 403</h4>
-    <p>You are pushing changes to a repository you don't have write access to. In this case, you're likely pushing ot
+    <p>You are pushing changes to a repository you don't have write access to. In this case, you're likely pushing to
         the original 'jlord/patchwork'. Make sure that you're pushing to 'origin' and that it points to your fork's
         address on GitHub. To check and see what your remotes are and where they point run <code>git remote -v</code>.
         You should have 'upstream' pointing to 'jlord/patchwork' and 'origin' pointing to 'yourusername/patchwork'.
@@ -122,3 +122,4 @@
         <li><code class="shell">git status</code></li>
     </ul>
 </div>
+


### PR DESCRIPTION
Fixed the typo in the 7th exercise (7_branches_arent_just_for_birds.html) line 83. Changed 'ot' to 'to'. Please merge it.