### PR TITLE
Add tooltip because of language barrier

### DIFF
--- a/assets/css/new-style.css
+++ b/assets/css/new-style.css
@@ -388,8 +388,6 @@ n, v, adj {
 [data-tooltip]:before,
 [data-tooltip]:after {
   visibility: hidden;
-  -ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=0)";
-  filter: progid: DXImageTransform.Microsoft.Alpha(Opacity=0);
   opacity: 0;
   pointer-events: none;
 }
@@ -435,7 +433,5 @@ n, v, adj {
 [data-tooltip]:hover:before,
 [data-tooltip]:hover:after {
   visibility: visible;
-  -ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=100)";
-  filter: progid: DXImageTransform.Microsoft.Alpha(Opacity=100);
   opacity: 1;
 }

--- a/assets/css/new-style.css
+++ b/assets/css/new-style.css
@@ -373,3 +373,69 @@ n, v, adj {
   white-space: nowrap;
   opacity: 0.8;
 }
+
+/* Tooltip
+    ------------------------------------------------------------------------- */
+[data-tooltip] {
+  position: relative;
+  z-index: 2;
+  cursor: pointer;
+  border-bottom: 1px dotted black;
+  color: inherit;
+}
+
+/* Hide the tooltip content by default */
+[data-tooltip]:before,
+[data-tooltip]:after {
+  visibility: hidden;
+  -ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=0)";
+  filter: progid: DXImageTransform.Microsoft.Alpha(Opacity=0);
+  opacity: 0;
+  pointer-events: none;
+}
+
+/* Position tooltip above the element */
+[data-tooltip]:before {
+  position: absolute;
+  bottom: 150%;
+  left: 50%;
+  margin-bottom: 5px;
+  margin-left: -80px;
+  padding: 7px;
+  width: 160px;
+  -webkit-border-radius: 3px;
+  -moz-border-radius: 3px;
+  border-radius: 3px;
+  background-color: #000;
+  background-color: hsla(0, 0%, 20%, 0.9);
+  color: #fff;
+  content: attr(data-tooltip);
+  text-align: center;
+  font-size: 14px;
+  line-height: 1.2;
+}
+
+/* Triangle hack to make tooltip look like a speech bubble */
+[data-tooltip]:after {
+  position: absolute;
+  bottom: 150%;
+  left: 50%;
+  margin-left: -5px;
+  width: 0;
+  border-top: 5px solid #000;
+  border-top: 5px solid hsla(0, 0%, 20%, 0.9);
+  border-right: 5px solid transparent;
+  border-left: 5px solid transparent;
+  content: " ";
+  font-size: 0;
+  line-height: 0;
+}
+
+/* Show tooltip content on hover */
+[data-tooltip]:hover:before,
+[data-tooltip]:hover:after {
+  visibility: visible;
+  -ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=100)";
+  filter: progid: DXImageTransform.Microsoft.Alpha(Opacity=100);
+  opacity: 1;
+}


### PR DESCRIPTION
![tooltip](https://user-images.githubusercontent.com/14804878/35487150-bcb8a678-0478-11e8-927a-5653ad191fd0.gif)

Why?

Here in Germany we use a lot of a mix of english and german words to describe terms original to git and GitHub. Which leads to the problem of not knowing how to translate these words. 
The easiest and most beginner friendly way, would be to add a tooltip to these words to add their translation which is also useful to have a translation for those scary command line words.

Hence i present a pure CSS tooltip:
```html
<span data-tooltip="Lagerstätte">Repository</span>
```
Simply add a ```data-tooltip``` attribute to any existing element with some text and boom,
it shall have a tooltip.