### PR TITLE
Error: Cannot find module 'shell'

### DIFF
--- a/menus/darwin-menu.js
+++ b/menus/darwin-menu.js
@@ -1,5 +1,5 @@
 var locale = require('../lib/locale.js')
-module.exports = function menu(app, mainWindow) {
+module.exports = function menu (app, mainWindow) {
   var darwinMenu = [
     {
       label: 'Git-it',

--- a/menus/darwin-menu.js
+++ b/menus/darwin-menu.js
@@ -1,5 +1,5 @@
 var locale = require('../lib/locale.js')
-module.exports = function menu (app, mainWindow) {
+module.exports = function menu(app, mainWindow) {
   var darwinMenu = [
     {
       label: 'Git-it',
@@ -127,7 +127,7 @@ module.exports = function menu (app, mainWindow) {
         {
           label: 'Repository',
           click: function () {
-            require('shell').openExternal('http://github.com/jlord/git-it-electron')
+            require('electron').shell.openExternal('http://github.com/jlord/git-it-electron')
           }
         },
         {


### PR DESCRIPTION
## Environment
```
Mac OS 10.13.3 (High Sierra)
Electron - v1.8.4
Node - v9.8.0
nom - v5.6.0
Git-it - v4.3.3 (master)
```

## Problem

When running the pre-built (v4.3.3 Mac-X64) or building it myself, I was getting a
`Uncaught Exception:Error: Cannot find module 'shell'` 

Click on Help -> Repository menu and the error pops up.

I updated the darwin-menu.js to use `shell.openExternal` like its done with Help -> Open Issue. This has corrected the error and the url opens.

## Error Message
```
Uncaught Exception:
Error: Cannot find module 'shell'
    at Module._resolveFilename (module.js:485:15)
    at Function.Module._resolveFilename (/Users/_user_/github/git-it-electron/node_modules/electron/dist/Electron.app/Contents/Resources/electron.asar/common/reset-search-paths.js:35:12)
    at Function.Module._load (module.js:437:25)
    at Module.require (module.js:513:17)
    at require (internal/module.js:11:18)
    at click (/Users/_user_/github/git-it-electron/menus/darwin-menu.js:130:13)
    at MenuItem.click (/Users/_user_/github/git-it-electron/node_modules/electron/dist/Electron.app/Contents/Resources/electron.asar/browser/api/menu-item.js:52:9)
    at Function.executeCommand (/Users/_user_/github/git-it-electron/node_modules/electron/dist/Electron.app/Contents/Resources/electron.asar/browser/api/menu.js:34:15)
```