### PR TITLE
Fixed slight typo

### DIFF
--- a/resources/contents/en-US/challenges/4_githubbin.html
+++ b/resources/contents/en-US/challenges/4_githubbin.html
@@ -27,7 +27,7 @@
             capitalized</strong>. Note, you don't need to enter the "&#60;" and "&#62;".</p>
 
     <p>Add your GitHub username to your Git configuration:</p>
-    <code class="shell">git config --global user.username &#60;USerNamE&#62;</code>
+    <code class="shell">git config --global user.username &#60;UserName&#62;</code>
 
     <p>You can double check what you have set in your Git config by typing:</p>
     <code>git config --global user.username</code>
@@ -48,6 +48,6 @@
         For instance, 'JLord' isn't the same as 'jlord'</p>
     <p>To change your username set with Git, just do the same command you did earlier, but with the correct
         capitalization:</p>
-    <p><code class="shell">git config --global user.username &#60;USerNamE&#62;</code></p>
+    <p><code class="shell">git config --global user.username &#60;UserName&#62;</code></p>
     <p>When you've made your updates, verify again!</p>
 </div>


### PR DESCRIPTION
I think this issue might have been left out intentionally to reflect the *capitalize where capitalized* part but, in my opinion, it does properly serve its purpose.
Alternatively, I propose that it is stated in the challenge that the username is *USerNamE*
![ScreenShot](https://user-images.githubusercontent.com/17203172/52900252-251afc80-320d-11e9-8e3d-f3a8d9ffc3e2.png)
