### PR TITLE
Update git installation section

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ As a part of the challenges you'll also create a (free) account on GitHub. If yo
 
 #### Git
 
-We recommend installing [GitHub Desktop](http://desktop.github.com) (free) because it installs Git in the most consistent way across supported operating systems (Windows and Mac). We won't use the app itself in the challenges (but it is really useful once you get going in Git!), just the Git that it install for you.
+We recommend installing Git on your computer by installing the [newest version](https://git-scm.com/downloads) from the Git website.
 
-Note—If you're using Windows, you should use the **Git Shell** app as your terminal—it is installed with GitHub Desktop. In Mac and Linux you can use the app **Terminal**, which is already on your computer.
+Note—If you're using Windows, you should use the **Git Shell** app as your terminal—it is installed with Git. In Mac and Linux you can use the app **Terminal**, which is already on your computer.
 
 #### Text Editor
 

--- a/resources/contents/en-US/challenges/1_get_git.html
+++ b/resources/contents/en-US/challenges/1_get_git.html
@@ -13,14 +13,11 @@
 
 <div class="chal-step blue-border border-box">
     <h3>Install Git</h3>
-    <p>We recommend installing Git on your computer by downloading the <a href="https://desktop.github.com">GitHub
-        Desktop</a> app. We'll not use the desktop app in Git-it (we're learning terminal!) but it includes Git and is
-        the easiest way to install Git on all platforms in the same way.</p>
+    <p>We recommend installing Git on your computer by installing the <a href="https://git-scm.com/downloads">newest version</a> from the Git website.</p>
 
     <ul>
         <li><strong>Windows</strong>: Use the <strong>Git Shell</strong> for your terminal.</li>
-        <li><strong>Mac</strong>: Open GitHub Desktop and from Preferences, select the command line tools install. Use
-            the <strong>terminal</strong> app as your terminal.
+        <li><strong>Mac</strong>: You can use the <strong>terminal</strong> app as your terminal.
         </li>
     </ul>
 
@@ -31,18 +28,19 @@
 
 <div class="chal-background light-blue solid-box">
     <h2>Git Software</h2>
-    <p>The GitHub Desktop app can do a lot of things with Git but not all, which is why learning the terminal is
+    <p>Git on its own isn't like other programs on your computer. You'll likely not see an icon on your desktop, but it
+        will always be available to you and you'll be able to access it at any time from your terminal or Git desktop
+        applications.</p>
+		
+	<p>GitHub provides such an desktop application, the <a href="https://desktop.github.com">GitHub Desktop</a> app.
+	 The GitHub Desktop app can do a lot of things with Git but not all, which is why learning the terminal is
         important. But once you've got that down, you'll be glad to have the desktop app because it organizes your
         project's information more visually, like the GitHub website.</p>
-
-    <p>Git on its own isn't like other programs on your computer. You'll likely not see an icon on your desktop, but it
-        will always be available to you and you'll be able to access it at anytime from your terminal or Git desktop
-        applications.</p>
 </div>
 
 <div class="chal-step blue-border border-box">
     <h3>Configure Git</h3>
-    <p>Once GitHub Desktop (and therefore Git) is installed, open your <strong>terminal</strong>.
+    <p>Once Git is installed, open your <strong>terminal</strong>.
         You can verify that Git is really there by typing:</p>
 
     <p><code class="shell">git --version </code></p>

--- a/resources/contents/fr-FR/challenges/1_get_git.html
+++ b/resources/contents/fr-FR/challenges/1_get_git.html
@@ -13,14 +13,11 @@
 
 <div class="chal-step blue-border border-box">
     <h3>Installer Git</h3>
-    <p>Nous vous recommandons d'installer Git sur votre ordinateur en téléchargeant <a href="https://desktop.github.com"> GitHub
-        Desktop </a>. Nous n'utiliserons pas l'application de bureau dans Git-it (uniquement le terminal!). Ce paquet 
-        logiciel comprend aussi Git et est la manière la plus simple d'installer Git sur les plates-formes non Linux.</p>
+    <p>Nous vous recommandons d'installer Git sur votre ordinateur en téléchargeant la <a href="https://git-scm.com/downloads">dernière version</a> du site web officiel de Git.</p>
 
     <ul>
         <li><strong> Windows </ strong>: Utilisez <strong> Git Shell </ strong> pour votre terminal.</li>
-        <li><strong> Mac </ strong>: ouvrez GitHub Desktop et, à partir des Préférences, sélectionnez l'installation des
-         outils de ligne de commande. Pour vous en servir utiliser l'application <strong> terminal </ strong>.</li>
+        <li><strong> Mac </ strong>: Pour vous en servir utiliser l'application <strong> terminal </ strong>.</li>
     </ul>
 
     <p>Vous avez déjà Git ou pas sûr? Tapez <code> git --version</ code> dans votre terminal et s'il renvoie un numéro de version
@@ -30,18 +27,18 @@
 
 <div class="chal-background light-blue solid-box">
     <h2>Git</h2>
-    <p>L'application GitHub Desktop peut faire beaucoup de choses avec Git mais pas tout, c'est pourquoi l'apprentissage 
+	<p>Git ne se ressemble pas à d'autres programmes sur votre ordinateur. Vous ne verrez probablement pas une icône sur 
+    votre bureau, mais il sera toujours disponible pour vous et vous pourrez y accéder à tout moment depuis votre terminal 
+    ou d'une git application.</p>
+	
+    <p>GitHub fournit une telle application desktop, <a href="https://desktop.github.com">GitHub Desktop</a>. L'application GitHub Desktop peut faire beaucoup de choses avec Git mais pas tout, c'est pourquoi l'apprentissage 
     du terminal est nécessaire. De temps à autre, vous serez heureux d'avoir l'application de bureau car elle organise 
     les informations des projets plus visuellement, comme le site web de GitHub.</p>
-
-    <p>Git ne se ressemble pas à d'autres programmes sur votre ordinateur. Vous ne verrez probablement pas une icône sur 
-    votre bureau, mais il sera toujours disponible pour vous et vous pourrez y accéder à tout moment depuis votre terminal 
-    ou de l'application GitHub Desktop.</p>
 </div>
 
 <div class="chal-step blue-border border-box">
     <h3>Configurer Git</h3>
-    <p>Une fois que GitHub Desktop (et donc Git) est installé, ouvrez votre <strong> terminal </ strong>.
+    <p>Une fois que Git est installé, ouvrez votre <strong> terminal </ strong>.
         Vous pouvez vérifier que Git existe vraiment en tapant:</p>
 
     <p><code class="shell">git --version </code></p>


### PR DESCRIPTION
According to #245 it seems like the Git Desktop App once provided a usable standalone git installation? For now, (at least on Windows) installing the deskop app does not install the terminal functionality.

Therefore i changed the installation section to install from the Git website directly and adapted the information on the desktop app. Maybe the **english formulation should be checked** by a native speaker.
Also to check is the **usage of the Git installation on mac**. This i can't test. ;)

Furthermore, i included the German translation directly in #254. **Other languages are still to translate.**

- [ ] Check english formulation
- [ ] Check installation on mac
- [ ] Translate es-CO
- [ ] Translate es-ES
- [x] Translate fr-FR
- [ ] Translate ja-JP
- [ ] Translate ko-KR
- [ ] Translate pt-BR
- [ ] Translate uk-UA
- [ ] Translate zh-TW