### PR TITLE
Adding a link to the GUI overview on resources page

### DIFF
--- a/resources/contents/en-US/pages/resources.html
+++ b/resources/contents/en-US/pages/resources.html
@@ -32,6 +32,7 @@
         <li><a href="https://desktop.github.com/">Github Desktop</a> (OSX, Windows) Free by GitHub</li>
         <li><a href="https://help.github.com/desktop/">Github Desktop Guides</a> by GitHub</li>
     </ul>
+	<p>You can checkout further git desktop applications on the Git website: <a href="https://www.git-scm.com/downloads/guis">Git GUIs</a></p>
 </div>
 
 <h2 id="what-next">What Next?</h2>


### PR DESCRIPTION
By accident i found the GUI-Page on the Git-Website. As i found a very good Desktop-Application for me there (GitKraken), it would be nice to include this link as additional info on the resources page.