### PR TITLE
Enable copy text functionality using menus, fixes #271

### DIFF
--- a/menus/darwin-menu.js
+++ b/menus/darwin-menu.js
@@ -45,6 +45,16 @@ module.exports = function menu (app, mainWindow) {
       ]
     },
     {
+      label: "Edit",
+      submenu: [
+        {
+          label: "Copy",
+          accelerator: "Command+C",
+          selector: "copy:"
+        }
+      ]
+    },
+    {
       label: 'View',
       submenu: [
         {

--- a/menus/other-menu.js
+++ b/menus/other-menu.js
@@ -18,6 +18,16 @@ module.exports = function menu (app, mainWindow) {
       ]
     },
     {
+      label: "Edit",
+      submenu: [
+        {
+          label: "Copy",
+          accelerator: "Ctrl+C",
+          selector: "copy:"
+        }
+      ]
+    },
+    {
       label: 'View',
       submenu: [
         {


### PR DESCRIPTION
Following the guide provided in issue #271: https://github.com/jlord/git-it-electron/issues/271
implemented copy text functionality.