### PR TITLE
Linux-ia32 packaging supported

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,6 +85,10 @@ This will output the contents of the application to a folder at `../out/Git-it-l
 $ npm run pack-win
 ```
 
+This will output the contents of the application to a folder at `../out/Git-it-linux-ia32`.
+```bash
+$ npm run pack-ia32
+
 A note from `electron-packager`, the module we use to package these apps:
 
 > **Building Windows apps from non-Windows platforms**

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "build-all": "npm run clean && npm run build-chals && npm run build-pages",
     "pack-mac": "electron-packager . Git-it --platform=darwin --arch=x64   --icon=assets/git-it.icns --overwrite --ignore=/out/ --ignore=assets/PortableGit --ignore=resources/ --prune=true --out=out",
     "pack-lin": "electron-packager . Git-it --platform=linux  --arch=x64   --icon=assets/git-it.png  --overwrite --ignore=/out/ --ignore=assets/PortableGit --ignore=resources/ --prune=true --out=out",
-    "pack-win": "electron-packager . Git-it --platform=win32  --arch=ia32  --icon=assets/git-it.ico  --overwrite --ignore=/out/ --ignore=resources/ --prune=true --out=out "
+    "pack-win": "electron-packager . Git-it --platform=win32  --arch=ia32  --icon=assets/git-it.ico  --overwrite --ignore=/out/ --ignore=resources/ --prune=true --out=out ",
+    "pack-ia32": "electron-packager . Git-it --platform=linux  --arch=ia32   --icon=assets/git-it.png  --overwrite --ignore=/out/ --ignore=assets/PortableGit --ignore=resources/ --prune=true --out=out"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Linux-ia32 architecture is used in Raspbian Desktop (based on Stretch).