### PR TITLE
Removed Git SHell

### DIFF
--- a/resources/contents/en-US/challenges/1_get_git.html
+++ b/resources/contents/en-US/challenges/1_get_git.html
@@ -13,12 +13,11 @@
 
 <div class="chal-step blue-border border-box">
     <h3>Install Git</h3>
-    <p>We recommend installing Git on your computer by downloading the <a href="https://desktop.github.com">GitHub
-        Desktop</a> app. We'll not use the desktop app in Git-it (we're learning terminal!) but it includes Git and is
-        the easiest way to install Git on all platforms in the same way.</p>
+    <p>We recommend installing Git on your computer by downloading it <a href="https://git-scm.com/downloads"> here</a>.
+    </p>
 
     <ul>
-        <li><strong>Windows</strong>: Use the <strong>Git Shell</strong> for your terminal.</li>
+        <li><strong>Windows</strong>: Use <strong>Git Bash</strong> for your terminal (it will install with Git).</li>
         <li><strong>Mac</strong>: Open GitHub Desktop and from Preferences, select the command line tools install. Use
             the <strong>terminal</strong> app as your terminal.
         </li>
@@ -31,7 +30,7 @@
 
 <div class="chal-background light-blue solid-box">
     <h2>Git Software</h2>
-    <p>The GitHub Desktop app can do a lot of things with Git but not all, which is why learning the terminal is
+    <p>The <a href="https://desktop.github.com/">GitHub Desktop</a> app can do a lot of things with Git but not all, which is why learning the terminal is
         important. But once you've got that down, you'll be glad to have the desktop app because it organizes your
         project's information more visually, like the GitHub website.</p>
 


### PR DESCRIPTION
Since Git now comes with its own command line tools and the Git Shell doesn't come with the GitHub desktop app. I made some changes to make it easy to follow along.