### PR TITLE
Replace Master with Main

### DIFF
--- a/lib/verify/remote_control.js
+++ b/lib/verify/remote_control.js
@@ -18,7 +18,7 @@ module.exports = function verifyRemoteControlChallenge (path) {
     addToList('Path is not a directory.', false)
     return helper.challengeIncomplete()
   }
-  exec('reflog show origin/master', {cwd: path}, function (err, stdout, stderr) {
+  exec('reflog show origin/main', {cwd: path}, function (err, stdout, stderr) {
     if (err) {
       addToList('Error: ' + err.message, false)
       return helper.challengeIncomplete()


### PR DESCRIPTION
Github changed the default branch name to main. This fixes #311

More work may need to be done to ensure this also works for older repositories