### PR TITLE
Change broken guides.github.com link

### DIFF
--- a/resources/contents/en-US/challenges/7_branches_arent_just_for_birds.html
+++ b/resources/contents/en-US/challenges/7_branches_arent_just_for_birds.html
@@ -18,7 +18,7 @@
          width="100%">
 
     <p>For a great visualization on how branches work in a project, see this GitHub Guide: <a
-            href="http://guides.github.com/overviews/flow/" target="_blank">guides.github.com/overviews/flow</a></p>
+            href="https://web.archive.org/web/20210226105433/https://guides.github.com/introduction/flow/" target="_blank">guides.github.com/overviews/flow</a></p>
 
     <h2>GitHub Pages</h2>
     <p>GitHub will automatically serve and host static website files in branches named 'gh-pages'. This free service is

--- a/resources/contents/es-CO/challenges/7_branches_arent_just_for_birds.html
+++ b/resources/contents/es-CO/challenges/7_branches_arent_just_for_birds.html
@@ -18,7 +18,7 @@
          width="100%">
 
     <p>Para una mejor entendimiento de cómo funcionan las ramas en un proyecto, revisa la guía de GitHub: <a
-            href="http://guides.github.com/overviews/flow/" target="_blank">guides.github.com/overviews/flow</a> (en inglés)</p>
+            href="https://web.archive.org/web/20210226105433/https://guides.github.com/introduction/flow/" target="_blank">guides.github.com/overviews/flow</a> (en inglés)</p>
 
     <h2>Páginas de GitHub</h2>
     <p>GitHub automáticamente servirá y alojará sitio web de archivos estáticos en las ramas branches nombradas cómo 'gh-pages'. Este servicio gratuito

--- a/resources/contents/es-ES/challenges/7_branches_arent_just_for_birds.html
+++ b/resources/contents/es-ES/challenges/7_branches_arent_just_for_birds.html
@@ -18,7 +18,7 @@
          width="100%">
 
     <p>Para entender mejor cómo funcionan las ramas en un proyecto, revisa la guía de GitHub: <a
-            href="http://guides.github.com/overviews/flow/" target="_blank">guides.github.com/overviews/flow</a> (en inglés)</p>
+            href="https://web.archive.org/web/20210226105433/https://guides.github.com/introduction/flow/" target="_blank">guides.github.com/overviews/flow</a> (en inglés)</p>
 
     <h2>Páginas de GitHub</h2>
     <p>GitHub automáticamente servirá y alojará un sitio web de archivos estáticos en las ramas o branches nombradas 'gh-pages'. Este servicio gratuito

--- a/resources/contents/fr-FR/challenges/7_branches_arent_just_for_birds.html
+++ b/resources/contents/fr-FR/challenges/7_branches_arent_just_for_birds.html
@@ -19,7 +19,7 @@
          width="100%">
 
     <p>Pour une excellente visualisation sur la façon dont les branches fonctionnent dans un projet, consultez ce guide 
-    GitHub: <a href="http://guides.github.com/overviews/flow/" target="_blank">guides.github.com/overviews/flow</a></p>
+    GitHub: <a href="https://web.archive.org/web/20210226105433/https://guides.github.com/introduction/flow/" target="_blank">guides.github.com/overviews/flow</a></p>
 
     <h2>GitHub Pages</h2>
     <p>GitHub hébergera automatiquement les fichiers de sites statiques. Pour être accessible comme un site web, il 

--- a/resources/contents/ja-JP/challenges/7_branches_arent_just_for_birds.html
+++ b/resources/contents/ja-JP/challenges/7_branches_arent_just_for_birds.html
@@ -12,7 +12,7 @@
 
 
 <p>ブランチがどんな風に役に立つのかについては、次を見てみてください。
-    GitHub Guide: <a href="http://guides.github.com/overviews/flow/"
+    GitHub Guide: <a href="https://web.archive.org/web/20210226105433/https://guides.github.com/introduction/flow/"
                      target="_blank">guides.github.com/overviews/flow</a></p>
 
 <h2>GitHub Pages</h2>

--- a/resources/contents/ko-KR/challenges/7_branches_arent_just_for_birds.html
+++ b/resources/contents/ko-KR/challenges/7_branches_arent_just_for_birds.html
@@ -10,7 +10,7 @@
 
   <img src="../../../assets/imgs/branches.png" alt="A diagram showing a horizontal line, representing the master branch, with another line branching off the top and later re-joining the original. Another line branches off the master branch line from below and yet another branch branches off of that. Both of these meet back up with the original master line, too." width="100%">
 
-  <p>프로젝트에서 브랜치 작업이 어떻게 이루어지는지에 대한 훌륭한 시각화를 이 GitHub Guide 에서 볼 수 있습니다: <a href="https://guides.github.com/introduction/flow/" target="_blank">guides.github.com/introduction/flow/</a></p>
+  <p>프로젝트에서 브랜치 작업이 어떻게 이루어지는지에 대한 훌륭한 시각화를 이 GitHub Guide 에서 볼 수 있습니다: <a href="https://web.archive.org/web/20210226105433/https://guides.github.com/introduction/flow/" target="_blank">guides.github.com/introduction/flow/</a></p>
 
   <h2>GitHub Pages</h2>
   <p>GitHub는 이름이 'gh-pages' 인 브랜치에 있는 정적 웹사이트 파일들을 자동으로 제공/호스팅 해줍니다. 이 무료 서비스를 <a href="http://pages.github.com">GitHub Pages</a> 라고 부릅니다. 당신이 포크한 프로젝트는 웹사이트를 만든 것이여서, 주 브랜치가 'master' 대신 'gh-pages' 입니다. 웹사이트 파일들이 있는 'gh-pages' 브랜치를 가진 모든 저장소는 다음 패턴의 URL을 통해 온라인으로 접근할 수 있습니다:</p>

--- a/resources/contents/pt-BR/challenges/7_branches_arent_just_for_birds.html
+++ b/resources/contents/pt-BR/challenges/7_branches_arent_just_for_birds.html
@@ -10,7 +10,7 @@
 
   <img src="../../../assets/imgs/branches-ptbr.png" width="100%">
 
-  <p>Para ter uma melhor ideia de como os branches funcionam em um projeto, veja este guia do GitHub: <a href="http://guides.github.com/overviews/flow/" target="_blank">guides.github.com/overviews/flow</a></p>
+  <p>Para ter uma melhor ideia de como os branches funcionam em um projeto, veja este guia do GitHub: <a href="https://web.archive.org/web/20210226105433/https://guides.github.com/introduction/flow/" target="_blank">guides.github.com/overviews/flow</a></p>
 
   <h2>Páginas do GitHub</h2>
   <p>O GitHub vai, automaticamente, servir e hospedar arquivos de websites estáticos em branches nomeados "gh-pages". Este serviço gratuito é chamado <a href="http://pages.github.com">GitHub Pages</a>. Como o projeto que você fez fork cria um website, seu branch principal é chamado de "gh-pages" ao invés de "master". Todos os repositórios que possuem um branch chamado "gh-pages" com arquivos de um website podem ser encontrados, na versão hospedada, usando o seguinte padrão para o URL:</p>

--- a/resources/contents/uk-UA/challenges/7_branches_arent_just_for_birds.html
+++ b/resources/contents/uk-UA/challenges/7_branches_arent_just_for_birds.html
@@ -18,7 +18,7 @@
          width="100%">
 
     <p>Для кращого розуміння того .як працюють гілки, дивіться GitHub Guide: <a
-            href="http://guides.github.com/overviews/flow/" target="_blank">guides.github.com/overviews/flow</a></p>
+            href="https://web.archive.org/web/20210226105433/https://guides.github.com/introduction/flow/" target="_blank">guides.github.com/overviews/flow</a></p>
 
     <h2>GitHub Сторінки</h2>
     <p>GitHub буде автоматично слідкувати та хостити статичні вебсайти із файлів у гілці 'gh-pages'. Цей безкоштовний сервіс називається <a href="http://pages.github.com">GitHub Pages</a>. Так як проект який ви форкаєте створює вебсайт,

--- a/resources/contents/zh-TW/challenges/7_branches_arent_just_for_birds.html
+++ b/resources/contents/zh-TW/challenges/7_branches_arent_just_for_birds.html
@@ -10,7 +10,7 @@
     <img src="../../../assets/imgs/branches.png"
          alt="A diagram showing a horizontal line, representing the master branch, with another line branching off the top and later re-joining the original. Another line branches off the master branch line from below and yet another branch branches off of that. Both of these meet back up with the original master line, too."
          width="100%">
-    <p>在 GitHub 導覽中有張不錯的示意圖，解釋在專案中 branches 是如何運作的：<a href="https://guides.github.com/overviews/flow/" target="_blank">guides.github.com/overviews/flow</a>
+    <p>在 GitHub 導覽中有張不錯的示意圖，解釋在專案中 branches 是如何運作的：<a href="https://web.archive.org/web/20210226105433/https://guides.github.com/introduction/flow/" target="_blank">guides.github.com/overviews/flow</a>
     </p>
     <h2>GitHub Pages</h2>
     <p>GitHub 會自動發佈你放在「gh-pages」 branch 裡的靜態檔案，並架設一個網站。這個免費服務叫做 <a href="http://pages.github.com">GitHub Pages</a>。如果你要為你


### PR DESCRIPTION
The link to guides.github.com in Challenge 7 ("Branches Aren't Just for Birds") is broken (the one underlined in red in the picture). 
![Screenshot 2022-04-13 165257](https://user-images.githubusercontent.com/23091991/163270864-cf1c1ec5-e782-4afe-a224-a9dd5b45c250.png)

It seems like github forwards guides.github.com to docs.github.com now. I couldn't find an equivalent docs page to the old guides one being linked to, but I think the old page has a rather helpful demonstration, so rather than deleting the link and reference altogether, I've changed it to a link to the Internet Archive's mirror of the old guides.github page. This was done for the challenge 7 file for each language.